### PR TITLE
feat: support for prometheus alertmanager

### DIFF
--- a/docs/services/alertmanager.md
+++ b/docs/services/alertmanager.md
@@ -1,0 +1,106 @@
+# Alertmanager
+
+## Parameters
+
+The notification service is used to push events to [Alertmanager](https://github.com/prometheus/alertmanager), and the following settings need to be specified:
+
+* `targets` - the alertmanager server address is an array, you can configure multiple
+* `scheme` - default is "http", e.g. http or https
+* `apiPath` - default is "/api/v2/alerts"
+* `insecureSkipVerify` - default is "false", when scheme is https whether to skip the verification of ca
+* `basicAuth` - server auth
+* `bearerToken` - server auth
+
+## Templates
+
+```yaml
+context: |
+  argocdUrl: https://example.com/argocd
+
+template.app-deployed: |
+  message: Application {{.app.metadata.name}} has been healthy.
+  alertmanager:
+    labels:
+      fault_priority: "P5"
+      event_bucket: "deploy"
+      event_status: "succeed"
+      recipient: "{{.recipient}}"
+    annotations:
+      application: '<a href="{{.context.argocdUrl}}/applications/{{.app.metadata.name}}">{{.app.metadata.name}}</a>'
+      author: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}"
+      message: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}"
+```
+
+You can do targeted push on [Alertmanager](https://github.com/prometheus/alertmanager) according to labels.
+
+## Example
+
+### Prometheus Alertmanager config
+
+```yaml
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: 'default'
+receivers:
+- name: 'default'
+  webhook_configs:
+  - send_resolved: false
+    url: 'http://10.5.39.39:10080/api/alerts/webhook'
+```
+
+You should turn off "send_resolved" or you will receive unnecessary recovery notifications after "resolve_timeout".
+
+### Send one alertmanager
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.alertmanager: |
+    targets:
+    - 10.5.39.39:9093
+```
+
+### Send alertmanager cluster with auth
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.alertmanager: |
+    targets:
+    - 10.5.39.39:19093
+    - 10.5.39.39:29093
+    - 10.5.39.39:39093
+    scheme: https
+    #apiPath: /api/events
+    #insecureSkipVerify: true
+    #basicAuth:
+    #  username: $alertmanager-username
+    #  password: $alertmanager-password   
+    bearerToken: $alertmanager-bearer-token
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  alertmanager-username: <username>
+  alertmanager-password: <password>
+  alertmanager-bearer-token: <token>
+```
+
+* "basicAuth" or "bearerToken" are used for authentication, and you can choose one.
+* If your alertmanager has changed the default api, you can customize "apiPath".

--- a/docs/services/alertmanager.md
+++ b/docs/services/alertmanager.md
@@ -149,3 +149,15 @@ template.app-deployed: |
 ```
 
 You can do targeted push on [Alertmanager](https://github.com/prometheus/alertmanager) according to labels.
+
+```yaml
+template.app-deployed: |
+  message: Application {{.app.metadata.name}} has been healthy.
+  alertmanager:
+    labels:
+      alertname: app-deployed
+      fault_priority: "P5"
+      event_bucket: "deploy"
+```
+
+There is a special label `alertname`. If you don’t set its value, it will be equal to the template name by default.

--- a/docs/services/alertmanager.md
+++ b/docs/services/alertmanager.md
@@ -10,6 +10,7 @@ The notification service is used to push events to [Alertmanager](https://github
 * `insecureSkipVerify` - optional, default is "false", when scheme is https whether to skip the verification of ca
 * `basicAuth` - optional, server auth
 * `bearerToken` - optional, server auth
+* `timeout` - optional, the timeout in seconds used when sending alerts, default is "3 seconds"
 
 `basicAuth` or `bearerToken` is used for authentication, you can choose one. If the two are set at the same time, `basicAuth` takes precedence over `bearerToken`.
 
@@ -124,7 +125,7 @@ data:
 
 ## Templates
 
-* `labels` - implement different notification strategies according to alertmanager routing
+* `labels` - at least one label pair required, implement different notification strategies according to alertmanager routing
 * `annotations` - optional, specifies a set of information labels, which can be used to store longer additional information, but only for display
 * `generatorURL` - optional, default is '{{.app.spec.source.repoURL}}', backlink used to identify the entity that caused this alert in the client
 

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -48,3 +48,4 @@ metadata:
 * [Telegram](./telegram.md)
 * [Teams](./teams.md)
 * [Rocket.Chat](./rocketchat.md)
+* [Alertmanager](./alertmanager.md)

--- a/pkg/services/alertmanager.go
+++ b/pkg/services/alertmanager.go
@@ -182,8 +182,7 @@ func (s alertmanagerService) sendOneTarget(target string, rawBody []byte) error 
 
 	if s.opts.BasicAuth != nil {
 		req.SetBasicAuth(s.opts.BasicAuth.Username, s.opts.BasicAuth.Password)
-	}
-	if s.opts.BearerToken != "" {
+	} else if s.opts.BearerToken != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %v", s.opts.BearerToken))
 	}
 
@@ -191,18 +190,18 @@ func (s alertmanagerService) sendOneTarget(target string, rawBody []byte) error 
 	if err != nil {
 		return err
 	}
-
-	if response.StatusCode != http.StatusOK {
-		data, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			data = []byte(fmt.Sprintf("unable to read response data: %v", err))
-		}
-		return fmt.Errorf("request to %s has failed with error code %d : %s", rawURL, response.StatusCode, string(data))
-	}
-
 	defer func() {
 		_ = response.Body.Close()
 	}()
+
+	data, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("unable to read response data: %v", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("request to %s has failed with error code %d : %s", rawURL, response.StatusCode, string(data))
+	}
 
 	return nil
 }

--- a/pkg/services/alertmanager.go
+++ b/pkg/services/alertmanager.go
@@ -10,8 +10,9 @@ import (
 	texttemplate "text/template"
 	"time"
 
-	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 	log "github.com/sirupsen/logrus"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 )
 
 const (
@@ -24,7 +25,6 @@ type AlertmanagerNotification struct {
 	Annotations  map[string]string `json:"annotations"`
 	GeneratorURL string            `json:"generatorURL"`
 	StartsAt     time.Time         `json:"startsAt"`
-	EndsAt       time.Time         `json:"endsAt"`
 }
 
 // AlertmanagerOptions cluster configuration

--- a/pkg/services/alertmanager.go
+++ b/pkg/services/alertmanager.go
@@ -65,7 +65,7 @@ func (n AlertmanagerNotification) GetTemplater(name string, f texttemplate.FuncM
 		}
 		notification.Alertmanager.StartsAt = time.Now()
 
-		tmplGeneratorURL := notification.Alertmanager.GeneratorURL
+		tmplGeneratorURL := n.GeneratorURL
 		if tmplGeneratorURL == "" {
 			tmplGeneratorURL = "{{.app.spec.source.repoURL}}"
 		}

--- a/pkg/services/alertmanager.go
+++ b/pkg/services/alertmanager.go
@@ -1,0 +1,208 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	texttemplate "text/template"
+	"time"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	alertNameLabel = "alertname"
+)
+
+// AlertmanagerNotification message body is similar to Prometheus alertmanager postableAlert model
+type AlertmanagerNotification struct {
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+	GeneratorURL string            `json:"generatorURL"`
+	StartsAt     time.Time         `json:"startsAt"`
+	EndsAt       time.Time         `json:"endsAt"`
+}
+
+// AlertmanagerOptions cluster configuration
+type AlertmanagerOptions struct {
+	Targets            []string   `json:"targets"`
+	Scheme             string     `json:"scheme"`
+	APIPath            string     `json:"apiPath"`
+	BasicAuth          *BasicAuth `json:"basicAuth"`
+	BearerToken        string     `json:"bearerToken"`
+	InsecureSkipVerify bool       `json:"insecureSkipVerify"`
+}
+
+// NewAlertmanagerService new service
+func NewAlertmanagerService(opts AlertmanagerOptions) NotificationService {
+	if len(opts.Targets) == 0 {
+		opts.Targets = append(opts.Targets, "127.0.0.1:9093")
+	}
+	if opts.Scheme == "" {
+		opts.Scheme = "http"
+	}
+	if opts.APIPath == "" {
+		opts.APIPath = "/api/v2/alerts"
+	}
+
+	return &alertmanagerService{entry: log.WithField("service", "alertmanager"), opts: opts}
+}
+
+type alertmanagerService struct {
+	entry *log.Entry
+	opts  AlertmanagerOptions
+}
+
+// GetTemplater parse text template
+func (n AlertmanagerNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
+	return func(notification *Notification, vars map[string]interface{}) error {
+		if notification.Alertmanager == nil {
+			notification.Alertmanager = &AlertmanagerNotification{}
+		}
+		notification.Alertmanager.StartsAt = time.Now()
+
+		tmplGeneratorURL := notification.Alertmanager.GeneratorURL
+		if tmplGeneratorURL == "" {
+			tmplGeneratorURL = "{{.app.spec.source.repoURL}}"
+		}
+		tmpl, err := texttemplate.New(name).Funcs(f).Parse(tmplGeneratorURL)
+		if err != nil {
+			return err
+		}
+		var tempData bytes.Buffer
+		if err := tmpl.Execute(&tempData, vars); err != nil {
+			return err
+		}
+		if val := tempData.String(); val != "" {
+			notification.Alertmanager.GeneratorURL = val
+		}
+		// generatorURL must url format
+		if _, err := url.Parse(notification.Alertmanager.GeneratorURL); err != nil {
+			return err
+		}
+
+		if len(n.Labels) > 0 {
+			notification.Alertmanager.Labels = n.Labels
+			if err := notification.Alertmanager.parseLabels(name, f, vars); err != nil {
+				return err
+			}
+		}
+		if len(n.Annotations) > 0 {
+			notification.Alertmanager.Annotations = n.Annotations
+			if err := notification.Alertmanager.parseAnnotations(name, f, vars); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, nil
+}
+
+func (n *AlertmanagerNotification) parseAnnotations(name string, f texttemplate.FuncMap, vars map[string]interface{}) error {
+	for k, v := range n.Annotations {
+		var tempData bytes.Buffer
+		tmpl, err := texttemplate.New(name).Funcs(f).Parse(v)
+		if err != nil {
+			return err
+		}
+		if err := tmpl.Execute(&tempData, vars); err != nil {
+			return err
+		}
+		if val := tempData.String(); val != "" {
+			n.Annotations[k] = val
+		}
+	}
+
+	return nil
+}
+
+func (n *AlertmanagerNotification) parseLabels(name string, f texttemplate.FuncMap, vars map[string]interface{}) error {
+	foundAlertname := false
+
+	for k, v := range n.Labels {
+		if k == alertNameLabel {
+			foundAlertname = true
+		}
+
+		var tempData bytes.Buffer
+		tmpl, err := texttemplate.New(name).Funcs(f).Parse(v)
+		if err != nil {
+			return err
+		}
+		if err := tmpl.Execute(&tempData, vars); err != nil {
+			return err
+		}
+		if val := tempData.String(); val != "" {
+			n.Labels[k] = val
+		}
+	}
+
+	if !foundAlertname {
+		n.Labels[alertNameLabel] = name
+	}
+
+	return nil
+}
+
+// Send using create alertmanager events
+func (s alertmanagerService) Send(notification Notification, dest Destination) error {
+	rawBody, err := json.Marshal([]*AlertmanagerNotification{notification.Alertmanager})
+	if err != nil {
+		return err
+	}
+
+	for _, target := range s.opts.Targets {
+		go func(target string) {
+			if err := s.sendOneTarget(target, rawBody); err != nil {
+				s.entry.Errorf("alertmanager sent target: %v", err)
+			}
+		}(target)
+	}
+
+	return nil
+}
+
+func (s alertmanagerService) sendOneTarget(target string, rawBody []byte) error {
+	rawURL := fmt.Sprintf("%v://%v%v", s.opts.Scheme, target, s.opts.APIPath)
+
+	transport := httputil.NewTransport(rawURL, s.opts.InsecureSkipVerify)
+	client := &http.Client{
+		Transport: httputil.NewLoggingRoundTripper(transport, s.entry),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, rawURL, bytes.NewReader(rawBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if s.opts.BasicAuth != nil {
+		req.SetBasicAuth(s.opts.BasicAuth.Username, s.opts.BasicAuth.Password)
+	}
+	if s.opts.BearerToken != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %v", s.opts.BearerToken))
+	}
+
+	response, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			data = []byte(fmt.Sprintf("unable to read response data: %v", err))
+		}
+		return fmt.Errorf("request to %s has failed with error code %d : %s", rawURL, response.StatusCode, string(data))
+	}
+
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	return nil
+}

--- a/pkg/services/alertmanager_test.go
+++ b/pkg/services/alertmanager_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"testing"
 	"text/template"
 
@@ -87,4 +88,21 @@ func TestGetTemplater_Alertmanager(t *testing.T) {
 
 		assert.Equal(t, "argocd-notifications", notification.Alertmanager.GeneratorURL)
 	})
+}
+
+func TestSend_Alertmanager(t *testing.T) {
+	opt := AlertmanagerOptions{
+		Targets: []string{
+			"127.0.0.1:9093",
+		},
+		Scheme:  "http",
+		APIPath: "/api/v2/alerts",
+		BasicAuth: &BasicAuth{
+			Username: "user",
+			Password: "pass",
+		},
+	}
+
+	assert.Equal(t, "http://127.0.0.1:9093/api/v2/alerts", fmt.Sprintf("%v://%v%v", opt.Scheme, opt.Targets[0], opt.APIPath))
+	assert.Equal(t, "user:pass", fmt.Sprintf("%v:%v", opt.BasicAuth.Username, opt.BasicAuth.Password))
 }

--- a/pkg/services/alertmanager_test.go
+++ b/pkg/services/alertmanager_test.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTemplater_Alertmanager(t *testing.T) {
+	n := Notification{
+		Alertmanager: &AlertmanagerNotification{
+			Labels: map[string]string{
+				"alertname": "App_Deployed",
+			},
+			Annotations: map[string]string{
+				"appname": "{{.app.metadata.name}}",
+			},
+			GeneratorURL: "{{.app.spec.source.repoURL}}",
+		},
+	}
+	templater, err := n.GetTemplater("", template.FuncMap{})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var notification Notification
+	err = templater(&notification, map[string]interface{}{
+		"app": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "argocd-notifications",
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"repoURL": "https://github.com/argoproj-labs/argocd-notifications.git",
+				},
+			},
+		},
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "App_Deployed", notification.Alertmanager.Labels["alertname"])
+	assert.Equal(t, "https://github.com/argoproj-labs/argocd-notifications.git", notification.Alertmanager.GeneratorURL)
+	assert.Equal(t, "argocd-notifications", notification.Alertmanager.Annotations["appname"])
+}

--- a/pkg/services/alertmanager_test.go
+++ b/pkg/services/alertmanager_test.go
@@ -16,17 +16,10 @@ func TestGetTemplater_Alertmanager(t *testing.T) {
 			Annotations: map[string]string{
 				"appname": "{{.app.metadata.name}}",
 			},
-			GeneratorURL: "{{.app.spec.source.repoURL}}",
 		},
 	}
-	templater, err := n.GetTemplater("", template.FuncMap{})
 
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	var notification Notification
-	err = templater(&notification, map[string]interface{}{
+	vars := map[string]interface{}{
 		"app": map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"name": "argocd-notifications",
@@ -37,13 +30,61 @@ func TestGetTemplater_Alertmanager(t *testing.T) {
 				},
 			},
 		},
-	})
-
-	if !assert.NoError(t, err) {
-		return
 	}
 
-	assert.Equal(t, "App_Deployed", notification.Alertmanager.Labels["alertname"])
-	assert.Equal(t, "https://github.com/argoproj-labs/argocd-notifications.git", notification.Alertmanager.GeneratorURL)
-	assert.Equal(t, "argocd-notifications", notification.Alertmanager.Annotations["appname"])
+	t.Run("test_Labels_Annotations", func(t *testing.T) {
+		templater, err := n.GetTemplater("", template.FuncMap{})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var notification Notification
+		err = templater(&notification, vars)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, "App_Deployed", notification.Alertmanager.Labels["alertname"])
+		assert.Equal(t, "argocd-notifications", notification.Alertmanager.Annotations["appname"])
+	})
+
+	t.Run("test_default_GeneratorURL", func(t *testing.T) {
+		templater, err := n.GetTemplater("", template.FuncMap{})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var notification Notification
+		err = templater(&notification, vars)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, "https://github.com/argoproj-labs/argocd-notifications.git", notification.Alertmanager.GeneratorURL)
+	})
+
+	t.Run("test_custom_GeneratorURL", func(t *testing.T) {
+		n.Alertmanager.GeneratorURL = "{{.app.metadata.name}}"
+
+		templater, err := n.GetTemplater("", template.FuncMap{})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var notification Notification
+		_ = templater(&notification, map[string]interface{}{
+			"app": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "argocd-notifications",
+				},
+				"spec": map[string]interface{}{
+					"source": map[string]interface{}{
+						"repoURL": "https://github.com/argoproj-labs/argocd-notifications.git",
+					},
+				},
+			},
+		})
+
+		assert.Equal(t, "argocd-notifications", notification.Alertmanager.GeneratorURL)
+	})
 }

--- a/pkg/services/alertmanager_test.go
+++ b/pkg/services/alertmanager_test.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"fmt"
 	"testing"
 	"text/template"
 
@@ -90,10 +89,12 @@ func TestGetTemplater_Alertmanager(t *testing.T) {
 	})
 }
 
-func TestSend_Alertmanager(t *testing.T) {
+func TestSend_AlertmanagerCluster(t *testing.T) {
 	opt := AlertmanagerOptions{
 		Targets: []string{
-			"127.0.0.1:9093",
+			"127.0.0.1:19093",
+			"127.0.0.1:29093",
+			"127.0.0.1:39093",
 		},
 		Scheme:  "http",
 		APIPath: "/api/v2/alerts",
@@ -101,8 +102,19 @@ func TestSend_Alertmanager(t *testing.T) {
 			Username: "user",
 			Password: "pass",
 		},
+		Timeout: 2,
 	}
 
-	assert.Equal(t, "http://127.0.0.1:9093/api/v2/alerts", fmt.Sprintf("%v://%v%v", opt.Scheme, opt.Targets[0], opt.APIPath))
-	assert.Equal(t, "user:pass", fmt.Sprintf("%v:%v", opt.BasicAuth.Username, opt.BasicAuth.Password))
+	notification := Notification{
+		Alertmanager: &AlertmanagerNotification{
+			Labels: map[string]string{
+				"alertname": "TestSend",
+			},
+		},
+	}
+
+	s := NewAlertmanagerService(opt)
+	if err := s.Send(notification, Destination{}); err != nil {
+		assert.EqualError(t, err, "no events were successfully received by alertmanager")
+	}
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -12,15 +12,16 @@ import (
 )
 
 type Notification struct {
-	Message    string                  `json:"message,omitempty"`
-	Email      *EmailNotification      `json:"email,omitempty"`
-	Slack      *SlackNotification      `json:"slack,omitempty"`
-	Mattermost *MattermostNotification `json:"mattermost,omitempty"`
-	RocketChat *RocketChatNotification `json:"rocketchat,omitempty"`
-	Teams      *TeamsNotification      `json:"teams,omitempty"`
-	Webhook    WebhookNotifications    `json:"webhook,omitempty"`
-	Opsgenie   *OpsgenieNotification   `json:"opsgenie,omitempty"`
-	GitHub     *GitHubNotification     `json:"github,omitempty"`
+	Message      string                    `json:"message,omitempty"`
+	Email        *EmailNotification        `json:"email,omitempty"`
+	Slack        *SlackNotification        `json:"slack,omitempty"`
+	Mattermost   *MattermostNotification   `json:"mattermost,omitempty"`
+	RocketChat   *RocketChatNotification   `json:"rocketchat,omitempty"`
+	Teams        *TeamsNotification        `json:"teams,omitempty"`
+	Webhook      WebhookNotifications      `json:"webhook,omitempty"`
+	Opsgenie     *OpsgenieNotification     `json:"opsgenie,omitempty"`
+	GitHub       *GitHubNotification       `json:"github,omitempty"`
+	Alertmanager *AlertmanagerNotification `json:"alertmanager,omitempty"`
 }
 
 // Destinations holds notification destinations group by trigger
@@ -80,6 +81,9 @@ func (n *Notification) GetTemplater(name string, f texttemplate.FuncMap) (Templa
 
 	if n.Teams != nil {
 		sources = append(sources, n.Teams)
+	}
+	if n.Alertmanager != nil {
+		sources = append(sources, n.Alertmanager)
 	}
 
 	return n.getTemplater(name, f, sources)
@@ -154,6 +158,12 @@ func NewService(serviceType string, optsData []byte) (NotificationService, error
 			return nil, err
 		}
 		return NewTeamsService(opts), nil
+	case "alertmanager":
+		var opts AlertmanagerOptions
+		if err := yaml.Unmarshal(optsData, &opts); err != nil {
+			return nil, err
+		}
+		return NewAlertmanagerService(opts), nil
 	default:
 		return nil, fmt.Errorf("service type '%s' is not supported", serviceType)
 	}


### PR DESCRIPTION
Prometheus alertmanager already including silencing, inhibition, aggregation and sending out notifications via some methods. I think it should be integrated.

Example config:

argocd-notifications-cm

```
  service.alertmanager: |
    targets:
      - 10.5.39.39:19093
      - 10.5.39.39:29093
      - 10.5.39.39:39093
    scheme: http
    apiPath: /api/v2/alerts
    insecureSkipVerify: true
```

alertmanager.yml

```
global:
  resolve_timeout: 5m

route:
  group_by: ['alertname']
  group_wait: 10s
  group_interval: 10s
  repeat_interval: 1h
  receiver: 'default'
receivers:
- name: 'default'
  webhook_configs:
  - send_resolved: false
    url: 'http://127.0.0.1:10080/api/alerts/webhook'
```

You must disable send_resolved.