### PR TITLE
feat: add message aggregation feature by slack threads API

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -91,3 +91,57 @@ template.app-sync-status: |
         }]
       }]
 ```
+
+The messages can be aggregated to the slack threads by grouping key which can be specified in a `groupingKey` string field under `slack` field.
+`groupingKey` is used across each template and works independently on each slack channel.
+When multiple applications will be updated at the same time or frequently, the messages in slack channel can be easily read by aggregating with git commit hash, application name, etc.
+Furthermore, the messages can be broadcast to the channel at the specific template by `notifyBroadcast` field.
+
+```yaml
+template.app-sync-status: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  slack:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+    # Aggregate the messages to the thread by git commit hash
+    groupingKey: "{{.app.status.sync.revision}}"
+    notifyBroadcast: false
+template.app-sync-failed: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  slack:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#ff0000",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+    # Aggregate the messages to the thread by git commit hash
+    groupingKey: "{{.app.status.sync.revision}}"
+    notifyBroadcast: true
+```

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -138,7 +138,7 @@ func (s *slackService) Send(notification Notification, dest Destination) error {
 		msgOptions = append(msgOptions, slack.MsgOptionBroadcast())
 	}
 
-	if lastTs, ok := threadTSs[dest.Recipient][notification.Slack.GroupingKey]; ok && lastTs != "" {
+	if lastTs, ok := threadTSs[dest.Recipient][notification.Slack.GroupingKey]; ok && lastTs != "" && notification.Slack.GroupingKey != "" {
 		msgOptions = append(msgOptions, slack.MsgOptionTS(lastTs))
 	}
 

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -19,10 +19,13 @@ import (
 
 // No rate limit unless Slack requests it (allows for Slack to control bursting)
 var rateLimiter = rate.NewLimiter(rate.Inf, 1)
+var threadTSs = map[string]map[string]string{}
 
 type SlackNotification struct {
-	Attachments string `json:"attachments,omitempty"`
-	Blocks      string `json:"blocks,omitempty"`
+	Attachments     string `json:"attachments,omitempty"`
+	Blocks          string `json:"blocks,omitempty"`
+	GroupingKey     string `json:"groupingKey"`
+	NotifyBroadcast bool   `json:"notifyBroadcast"`
 }
 
 func (n *SlackNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
@@ -34,6 +37,11 @@ func (n *SlackNotification) GetTemplater(name string, f texttemplate.FuncMap) (T
 	if err != nil {
 		return nil, err
 	}
+	groupingKey, err := texttemplate.New(name).Funcs(f).Parse(n.GroupingKey)
+	if err != nil {
+		return nil, err
+	}
+
 	return func(notification *Notification, vars map[string]interface{}) error {
 		if notification.Slack == nil {
 			notification.Slack = &SlackNotification{}
@@ -42,13 +50,21 @@ func (n *SlackNotification) GetTemplater(name string, f texttemplate.FuncMap) (T
 		if err := slackAttachments.Execute(&slackAttachmentsData, vars); err != nil {
 			return err
 		}
-
 		notification.Slack.Attachments = slackAttachmentsData.String()
+
 		var slackBlocksData bytes.Buffer
 		if err := slackBlocks.Execute(&slackBlocksData, vars); err != nil {
 			return err
 		}
 		notification.Slack.Blocks = slackBlocksData.String()
+
+		var groupingKeyData bytes.Buffer
+		if err := groupingKey.Execute(&groupingKeyData, vars); err != nil {
+			return err
+		}
+		notification.Slack.GroupingKey = groupingKeyData.String()
+
+		notification.Slack.NotifyBroadcast = n.NotifyBroadcast
 		return nil
 	}, nil
 }
@@ -114,6 +130,18 @@ func (s *slackService) Send(notification Notification, dest Destination) error {
 		msgOptions = append(msgOptions, slack.MsgOptionAttachments(attachments...), slack.MsgOptionBlocks(blocks.BlockSet...))
 	}
 
+	if _, ok := threadTSs[dest.Recipient]; !ok {
+		threadTSs[dest.Recipient] = map[string]string{}
+	}
+
+	if notification.Slack.NotifyBroadcast {
+		msgOptions = append(msgOptions, slack.MsgOptionBroadcast())
+	}
+
+	if lastTs, ok := threadTSs[dest.Recipient][notification.Slack.GroupingKey]; ok && lastTs != "" {
+		msgOptions = append(msgOptions, slack.MsgOptionTS(lastTs))
+	}
+
 	ctx := context.TODO()
 	var err error
 	for {
@@ -121,7 +149,7 @@ func (s *slackService) Send(notification Notification, dest Destination) error {
 		if err != nil {
 			break
 		}
-		_, _, err = sl.PostMessageContext(ctx, dest.Recipient, msgOptions...)
+		_, ts, err := sl.PostMessageContext(ctx, dest.Recipient, msgOptions...)
 		if err != nil {
 			if rateLimitedError, ok := err.(*slack.RateLimitedError); ok {
 				rateLimiter.SetLimit(rate.Every(rateLimitedError.RetryAfter))
@@ -129,6 +157,9 @@ func (s *slackService) Send(notification Notification, dest Destination) error {
 				break
 			}
 		} else {
+			if lastTs, ok := threadTSs[dest.Recipient][notification.Slack.GroupingKey]; !ok || lastTs == "" {
+				threadTSs[dest.Recipient][notification.Slack.GroupingKey] = ts
+			}
 			// No error, so remove rate limit
 			rateLimiter.SetLimit(rate.Inf)
 			break

--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -24,8 +24,10 @@ func TestValidIconURL(t *testing.T) {
 func TestGetTemplater_Slack(t *testing.T) {
 	n := Notification{
 		Slack: &SlackNotification{
-			Attachments: "{{.foo}}",
-			Blocks:      "{{.bar}}",
+			Attachments:     "{{.foo}}",
+			Blocks:          "{{.bar}}",
+			GroupingKey:     "{{.foo}}-{{.bar}}",
+			NotifyBroadcast: true,
 		},
 	}
 	templater, err := n.GetTemplater("", template.FuncMap{})
@@ -46,4 +48,6 @@ func TestGetTemplater_Slack(t *testing.T) {
 
 	assert.Equal(t, "hello", notification.Slack.Attachments)
 	assert.Equal(t, "world", notification.Slack.Blocks)
+	assert.Equal(t, "hello-world", notification.Slack.GroupingKey)
+	assert.Equal(t, true, notification.Slack.NotifyBroadcast)
 }

--- a/pkg/templates/service.go
+++ b/pkg/templates/service.go
@@ -44,5 +44,6 @@ func (s *service) FormatNotification(vars map[string]interface{}, templates ...s
 			return nil, err
 		}
 	}
+
 	return &notification, nil
 }


### PR DESCRIPTION
Support message aggregation feature by slack threads API.

Detail is following.
* https://github.com/argoproj-labs/argocd-notifications/issues/319

![image](https://user-images.githubusercontent.com/8783194/127752425-8d25fc47-742f-462e-bac2-91ba70cf8e3a.png)


