### PR TITLE
feat: support for Google Chat

### DIFF
--- a/docs/services/googlechat.md
+++ b/docs/services/googlechat.md
@@ -1,0 +1,81 @@
+# Google Chat
+
+## Parameters
+
+The Google Chat notification service send message notifications to a google chat webhook. This service uses the following settings:
+
+* `webhooks` - a map of the form `webhookName: webhookUrl`
+
+## Configuration
+
+1. Open `Google chat` and go to the space to which you want to send messages
+2. From the menu at the top of the page, select **Configure Webhooks**
+3. Under **Incoming Webhooks**, click **Add Webhook**
+4. Give a name to the webhook, optionally add an image and click **Save**
+5. Copy the URL next to your webhook
+6. Store the URL in `argocd-notification-secret` and declare it in `argocd-notifications-cm`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+data:
+  service.googlechat: |
+    webhooks:
+      spaceName: $space-webhook-url
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notification-secret
+stringData:
+  space-webhook-url: https://chat.googleapis.com/v1/spaces/<space_id>/messages?key=<key>&token=<token>  
+```
+
+6. Create a subscription for your space
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.googlechat: channelName
+```
+
+## Templates
+
+You can send [simple text](https://developers.google.com/chat/reference/message-formats/basic) or [card messages](https://developers.google.com/chat/reference/message-formats/cards) to a Google Chat space. A simple text message template can be defined as follows:
+
+```yaml
+template.app-sync-succeeded: |
+  message: The app {{ .app.metadata.name }} has succesfully synced!
+```
+
+A card message can be defined as follows:
+
+```yaml
+template.app-sync-succeeded: |
+  googlechat:
+    cards: |
+      - header:
+          title: ArgoCD Bot Notification
+        sections:
+          - widgets:
+              - textParagraph:
+                  text: The app {{ .app.metadata.name }} has succesfully synced!
+          - widgets:
+              - keyValue:
+                  topLabel: Repository
+                  content: {{ call .repo.RepoURLToHTTPS .app.spec.source.repoURL }}
+              - keyValue:
+                  topLabel: Revision
+                  content: {{ .app.spec.source.targetRevision }}
+              - keyValue:
+                  topLabel: Author
+                  content: {{ (call .repo.GetCommitMetadata .app.status.sync.revision).Author }}
+```
+
+The card message can be written in JSON too.

--- a/docs/services/googlechat.md
+++ b/docs/services/googlechat.md
@@ -19,7 +19,7 @@ The Google Chat notification service send message notifications to a google chat
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.googlechat: |
     webhooks:
@@ -30,7 +30,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argocd-notification-secret
+  name: <secret-name>
 stringData:
   space-webhook-url: https://chat.googleapis.com/v1/spaces/<space_id>/messages?key=<key>&token=<token>  
 ```
@@ -42,7 +42,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    notifications.argoproj.io/subscribe.on-sync-succeeded.googlechat: channelName
+    notifications.argoproj.io/subscribe.on-sync-succeeded.googlechat: spaceName
 ```
 
 ## Templates

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -47,4 +47,5 @@ metadata:
 * [Webhook](./webhook.md)
 * [Telegram](./telegram.md)
 * [Teams](./teams.md)
+* [Google Chat](./googlechat.md)
 * [Rocket.Chat](./rocketchat.md)

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -117,6 +117,12 @@ func (c *commandContext) getSecret() (*v1.Secret, error) {
 		if err := c.unmarshalFromFile(c.secretPath, c.SecretName, schema.GroupKind{Kind: "Secret"}, &secret); err != nil {
 			return nil, err
 		}
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		for k, v := range secret.StringData {
+			secret.Data[k] = []byte(v)
+		}
 	}
 	secret.Name = c.SecretName
 	secret.Namespace = c.namespace

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -68,7 +68,7 @@ func (c *commandContext) unmarshalFromFile(filePath string, name string, gk sche
 	if filePath == "-" {
 		data, err = ioutil.ReadAll(c.stdin)
 	} else {
-		data, err = ioutil.ReadFile(c.configMapPath)
+		data, err = ioutil.ReadFile(filePath)
 	}
 	if err != nil {
 		return err

--- a/pkg/services/googlechat.go
+++ b/pkg/services/googlechat.go
@@ -8,9 +8,10 @@ import (
 	"net/http"
 	texttemplate "text/template"
 
-	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 )
 
 type GoogleChatNotification struct {

--- a/pkg/services/googlechat.go
+++ b/pkg/services/googlechat.go
@@ -1,0 +1,144 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	texttemplate "text/template"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
+	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
+)
+
+type GoogleChatNotification struct {
+	Cards string `json:"cards"`
+}
+
+type googleChatMessage struct {
+	Text  string        `json:"text"`
+	Cards []cardMessage `json:"cards"`
+}
+
+type cardMessage struct {
+	Header   cardHeader    `json:"header,omitempty"`
+	Sections []cardSection `json:"sections"`
+}
+
+type cardHeader struct {
+	Title      string `json:"title,omitempty"`
+	Subtitle   string `json:"subtitle,omitempty"`
+	ImageUrl   string `json:"imageUrl,omitempty"`
+	ImageStyle string `json:"imageStyle,omitempty"`
+}
+
+type cardSection struct {
+	Header  string       `json:"header"`
+	Widgets []cardWidget `json:"widgets"`
+}
+
+type cardWidget struct {
+	TextParagraph map[string]interface{}   `json:"textParagraph,omitempty"`
+	Keyvalue      map[string]interface{}   `json:"keyValue,omitempty"`
+	Image         map[string]interface{}   `json:"image,omitempty"`
+	Buttons       []map[string]interface{} `json:"buttons,omitempty"`
+}
+
+func (n *GoogleChatNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
+	cards, err := texttemplate.New(name).Funcs(f).Parse(n.Cards)
+	if err != nil {
+		return nil, fmt.Errorf("error in '%s' googlechat.cards : %w", name, err)
+	}
+	return func(notification *Notification, vars map[string]interface{}) error {
+		if notification.GoogleChat == nil {
+			notification.GoogleChat = &GoogleChatNotification{}
+		}
+		var cardsBuff bytes.Buffer
+		if err := cards.Execute(&cardsBuff, vars); err != nil {
+			return err
+		}
+		if val := cardsBuff.String(); val != "" {
+			notification.GoogleChat.Cards = val
+		}
+		return nil
+	}, nil
+}
+
+type GoogleChatOptions struct {
+	WebhookUrls map[string]string `json:"webhooks"`
+}
+
+type googleChatService struct {
+	opts GoogleChatOptions
+}
+
+func NewGoogleChatService(opts GoogleChatOptions) NotificationService {
+	return &googleChatService{opts: opts}
+}
+
+type webhookReturn struct {
+	Error *webhookError `json:"error"`
+}
+
+type webhookError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status"`
+}
+
+func (s googleChatService) Send(notification Notification, dest Destination) error {
+	webhookUrl, ok := s.opts.WebhookUrls[dest.Recipient]
+	if !ok {
+		return fmt.Errorf("no Google chat webhook configured for recipient %s", dest.Recipient)
+	}
+	transport := httputil.NewTransport(webhookUrl, false)
+	client := &http.Client{
+		Transport: httputil.NewLoggingRoundTripper(transport, log.WithField("service", "googlechat")),
+	}
+	message, err := googleChatNotificationToMessage(notification)
+	if err != nil {
+		return err
+	}
+	jsonMessage, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	response, err := client.Post(webhookUrl, "application/json", bytes.NewReader(jsonMessage))
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	body := webhookReturn{}
+	err = json.Unmarshal(bodyBytes, &body)
+	if err != nil {
+		return err
+	}
+	if body.Error != nil {
+		return fmt.Errorf("error with message: code=%d status=%s message=%s", body.Error.Code, body.Error.Status, body.Error.Message)
+	}
+	return nil
+}
+
+func googleChatNotificationToMessage(n Notification) (*googleChatMessage, error) {
+	message := &googleChatMessage{}
+	if n.GoogleChat != nil && n.GoogleChat.Cards != "" {
+		err := yaml.Unmarshal([]byte(n.GoogleChat.Cards), &message.Cards)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		message.Text = n.Message
+	}
+	return message, nil
+}

--- a/pkg/services/googlechat.go
+++ b/pkg/services/googlechat.go
@@ -136,16 +136,16 @@ func (c *googlechatClient) sendMessage(message *googleChatMessage) (*webhookRetu
 func (s googleChatService) Send(notification Notification, dest Destination) error {
 	client, err := s.getClient(dest.Recipient)
 	if err != nil {
-		return fmt.Errorf("error creating client to webhook: %s", err)
+		return fmt.Errorf("error creating client to webhook: %w", err)
 	}
 	message, err := googleChatNotificationToMessage(notification)
 	if err != nil {
-		return fmt.Errorf("cannot create message: %s", err)
+		return fmt.Errorf("cannot create message: %w", err)
 	}
 
 	body, err := client.sendMessage(message)
 	if err != nil {
-		return fmt.Errorf("cannot create message: %s", err)
+		return fmt.Errorf("cannot send message: %w", err)
 	}
 	if body.Error != nil {
 		return fmt.Errorf("error with message: code=%d status=%s message=%s", body.Error.Code, body.Error.Status, body.Error.Message)

--- a/pkg/services/googlechat_test.go
+++ b/pkg/services/googlechat_test.go
@@ -22,7 +22,7 @@ func TestTextMessage_GoogleChat(t *testing.T) {
 
 	notification := Notification{}
 
-	templater(&notification, map[string]interface{}{
+	err = templater(&notification, map[string]interface{}{
 		"value": "value",
 	})
 
@@ -66,7 +66,7 @@ func TestCardMessage_GoogleChat(t *testing.T) {
 
 	notification := Notification{}
 
-	templater(&notification, map[string]interface{}{
+	err = templater(&notification, map[string]interface{}{
 		"text":     "text",
 		"topLabel": "topLabel",
 		"imageUrl": "imageUrl",
@@ -140,7 +140,10 @@ func TestSendMessage_NoError(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		called = true
 		res.WriteHeader(http.StatusOK)
-		res.Write([]byte("{}"))
+		_, err := res.Write([]byte("{}"))
+		if err != nil {
+			t.Fatal("error on write response body")
+		}
 	}))
 	defer func() { testServer.Close() }()
 

--- a/pkg/services/googlechat_test.go
+++ b/pkg/services/googlechat_test.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTextMessage_GoogleChat(t *testing.T) {
+	notificationTemplate := Notification{
+		Message: "message {{.value}}",
+	}
+
+	templater, err := notificationTemplate.GetTemplater("test", template.FuncMap{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	notification := Notification{}
+
+	templater(&notification, map[string]interface{}{
+		"value": "value",
+	})
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	message, err := googleChatNotificationToMessage(notification)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assert.NotNil(t, message)
+	assert.Equal(t, message.Text, "message value")
+}
+
+func TestCardMessage_GoogleChat(t *testing.T) {
+	notificationTemplate := Notification{
+		GoogleChat: &GoogleChatNotification{
+			Cards: `- sections:
+  - widgets:
+    - textParagraph:
+        text: {{.text}}
+    - keyValue:
+        topLabel: {{.topLabel}}
+    - image:
+        imageUrl: {{.imageUrl}}
+    - buttons:
+      - textButton:
+          text: {{.button}}`,
+		},
+	}
+
+	templater, err := notificationTemplate.GetTemplater("test", template.FuncMap{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	notification := Notification{}
+
+	templater(&notification, map[string]interface{}{
+		"text":     "text",
+		"topLabel": "topLabel",
+		"imageUrl": "imageUrl",
+		"button":   "button",
+	})
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	message, err := googleChatNotificationToMessage(notification)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assert.NotNil(t, message)
+	assert.Equal(t, message.Cards, []cardMessage{
+		{
+			Sections: []cardSection{
+				{
+					Widgets: []cardWidget{
+						{
+							TextParagraph: map[string]interface{}{
+								"text": "text",
+							},
+						}, {
+							Keyvalue: map[string]interface{}{
+								"topLabel": "topLabel",
+							},
+						}, {
+							Image: map[string]interface{}{
+								"imageUrl": "imageUrl",
+							},
+						}, {
+							Buttons: []map[string]interface{}{
+								{
+									"textButton": map[string]interface{}{
+										"text": "button",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -21,6 +21,7 @@ type Notification struct {
 	Webhook    WebhookNotifications    `json:"webhook,omitempty"`
 	Opsgenie   *OpsgenieNotification   `json:"opsgenie,omitempty"`
 	GitHub     *GitHubNotification     `json:"github,omitempty"`
+	GoogleChat *GoogleChatNotification `json:"googlechat,omitempty"`
 }
 
 // Destinations holds notification destinations group by trigger
@@ -80,6 +81,10 @@ func (n *Notification) GetTemplater(name string, f texttemplate.FuncMap) (Templa
 
 	if n.Teams != nil {
 		sources = append(sources, n.Teams)
+	}
+
+	if n.GoogleChat != nil {
+		sources = append(sources, n.GoogleChat)
 	}
 
 	return n.getTemplater(name, f, sources)
@@ -154,6 +159,12 @@ func NewService(serviceType string, optsData []byte) (NotificationService, error
 			return nil, err
 		}
 		return NewTeamsService(opts), nil
+	case "googlechat":
+		var opts GoogleChatOptions
+		if err := yaml.Unmarshal(optsData, &opts); err != nil {
+			return nil, err
+		}
+		return NewGoogleChatService(opts), nil
 	default:
 		return nil, fmt.Errorf("service type '%s' is not supported", serviceType)
 	}


### PR DESCRIPTION
Google chat uses json for its webhook input format. Even though there's already a webhook service, a customized one can be more pleasant to use.
This PR addresses #23 