### PR TITLE
chore: drop reflection based slack client tests

### DIFF
--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"reflect"
-	"runtime"
 	"testing"
 	"text/template"
 
@@ -64,30 +62,4 @@ func TestBuildMessageOptionsWithNonExistTemplate(t *testing.T) {
 	assert.Len(t, opts, 1)
 	assert.Empty(t, sn.GroupingKey)
 	assert.Equal(t, slackutil.Post, sn.DeliveryPolicy)
-}
-
-func TestBuildMessageOptionsUsername(t *testing.T) {
-	n := Notification{}
-
-	_, opts, err := buildMessageOptions(n, Destination{}, SlackOptions{Username: "test-username"})
-	assert.NoError(t, err)
-	assert.Len(t, opts, 2)
-
-	usernameOption := opts[1]
-
-	val := runtime.FuncForPC(reflect.ValueOf(usernameOption).Pointer()).Name()
-	assert.Contains(t, val, "MsgOptionUsername")
-}
-
-func TestBuildMessageOptionsIcon(t *testing.T) {
-	n := Notification{}
-
-	_, opts, err := buildMessageOptions(n, Destination{}, SlackOptions{Icon: ":+1:"})
-	assert.NoError(t, err)
-	assert.Len(t, opts, 2)
-
-	usernameOption := opts[1]
-
-	val := runtime.FuncForPC(reflect.ValueOf(usernameOption).Pointer()).Name()
-	assert.Contains(t, val, "MsgOptionIconEmoji")
 }

--- a/pkg/util/slack/client_test.go
+++ b/pkg/util/slack/client_test.go
@@ -3,10 +3,7 @@ package slack
 import (
 	"context"
 	"encoding/json"
-	"reflect"
-	"runtime"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/argoproj/notifications-engine/pkg/util/slack/mocks"
@@ -56,23 +53,6 @@ func TestDeliveryPolicy_UnmarshalJSON(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
-}
-
-type msgOptionMatcher struct {
-	name string
-}
-
-func (m msgOptionMatcher) Matches(option interface{}) bool {
-	name := runtime.FuncForPC(reflect.ValueOf(option).Pointer()).Name()
-	return strings.Contains(name, m.name)
-}
-
-func (m msgOptionMatcher) String() string {
-	return m.name
-}
-
-func EqMsgOption(name string) gomock.Matcher {
-	return msgOptionMatcher{name}
 }
 
 func TestThreadedClient(t *testing.T) {
@@ -155,12 +135,12 @@ func TestThreadedClient(t *testing.T) {
 			m := mocks.NewMockSlackClient(ctrl)
 
 			m.EXPECT().
-				SendMessageContext(gomock.Any(), gomock.Any(), EqMsgOption(tc.wantOpt1)).
+				SendMessageContext(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(channel, ts1, "", nil)
 
 			if tc.wantOpt2 != "" {
 				m.EXPECT().
-					SendMessageContext(gomock.Any(), gomock.Any(), EqMsgOption(tc.wantOpt2))
+					SendMessageContext(gomock.Any(), gomock.Any(), gomock.Any())
 			}
 
 			client := NewThreadedClient(m, &state{rate.NewLimiter(rate.Inf, 1), tc.threadTSs, channelMap{}})


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj/notifications-engine/issues/70

Reflection-based tests are pretty fragile and expensive to maintain. So I propose to drop them instead of spending time after every golang upgrade.