### PR TITLE
bug: PagerDuty Service uses PagerDuty Incident Creation API

### DIFF
--- a/docs/services/pagerduty.md
+++ b/docs/services/pagerduty.md
@@ -1,5 +1,12 @@
 # Pagerduty
 
+The [PagerDuty Events API v2](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgw-events-api-v2-overview#events-api-v2-overview) is a highly available asynchronous API that routes events sent to a [PagerDuty service](https://support.pagerduty.com/docs/services-and-integrations) for processing. can ingest multiple types of events. Each event type is described below
+
+| API | Type | Description | Example |
+|---|---|---|---|
+| PagerDuty v2 Events API | Alert Event | A problem in a machine monitored system.   Follow up events can be sent to acknowledge or resolve an existing alert. | - High error rate - CPU usage exceeded limit - Deployment failed |
+| PagerDuty v2 Events API | Change Event | A change in a system that does not represent a problem. | Pull request merged   Secret successfully rotated   Configuration update applied |
+
 ## Parameters
 
 The Pagerduty notification service is used to create pagerduty incidents and requires specifying the following settings:


### PR DESCRIPTION

[provide general introduction to the issue logging and why it is relevant to this repository]

## Context

[provide more detailed introduction to the issue itself and why it is relevant]

## Process

[ordered list the process to finding and recreating the issue, example below]

1. User goes to delete a dataset (to save space or whatever)
2. User gets popup modal warning
3. User deletes and it's lost forever

## Expected result

[describe what you would expect to have resulted from this process]

## Current result

[describe what you you currently experience from this process, and thereby explain the bug]

## Possible Fix

[not obligatory, but suggest fixes or reasons for the bug]

* Modal tells the user what dataset is being deleted, like “You are about to delete this dataset: car_crashes_2014.”
* A temporary "Trashcan" where you can recover a just deleted dataset if you mess up (maybe it's only good for a few hours, and then it cleans the cache assuming you made the right decision).

## `name of issue` screenshot

[if relevant, include a screenshot]