### PR TITLE
fix: refer to the revision of a specific sync operation instead of the current revision

### DIFF
--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -44,7 +44,7 @@ type GitHubStatus struct {
 
 const (
 	repoURLtemplate  = "{{.app.spec.source.repoURL}}"
-	revisionTemplate = "{{.app.status.sync.revision}}"
+	revisionTemplate = "{{.app.status.operationState.syncResult.revision}}"
 )
 
 func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -39,8 +39,10 @@ func TestGetTemplater_GitHub(t *testing.T) {
 				},
 			},
 			"status": map[string]interface{}{
-				"sync": map[string]interface{}{
-					"revision": "0123456789",
+				"operationState": map[string]interface{}{
+					"syncResult": map[string]interface{}{
+						"revision": "0123456789",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This is for fixing https://github.com/argoproj/notifications-engine/issues/90