### PR TITLE
feat(services): add NewRelic service

### DIFF
--- a/docs/services/newrelic.md
+++ b/docs/services/newrelic.md
@@ -16,7 +16,7 @@ kind: ConfigMap
 metadata:
   name: <config-map-name>
 data:
-  service.mattermost: |
+  service.newrelic: |
     apiURL: <api-url>
     apiKey: $newrelic-apiKey
 ```
@@ -43,16 +43,19 @@ metadata:
 
 ## Templates
 
-* `description` - A high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment. Defaults to `message`
-* `changelog` - optional, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log
+* `description` - __optional__, high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment.
+  * Defaults to `message`
+* `changelog` - __optional__, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log.
+  * Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}`
+* `user` - __optional__, A username to associate with the deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page).
+  * Defaults to `{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}`
 
 ```yaml
 context: |
   argocdUrl: https://example.com/argocd
 
 template.app-deployed: |
-  message: Application {{.app.metadata.name}} has been healthy.
+  message: Application {{.app.metadata.name}} has successfully deployed.
   newrelic:
-    description: Application {{.app.metadata.name}} has been healthy
-    changelog: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}"
+    description: Application {{.app.metadata.name}} has successfully deployed
 ```

--- a/docs/services/newrelic.md
+++ b/docs/services/newrelic.md
@@ -1,0 +1,58 @@
+# NewRelic
+
+## Parameters
+
+* `apiURL` - the api server url, e.g. https://api.newrelic.com
+* `apiKey` - a [NewRelic ApiKey](https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2/#api_key)
+
+## Configuration
+
+1. Create a NewRelic [Api Key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-api-key)
+2. Store apiKey in `argocd-notifications-secret` Secret and configure NewRelic integration in `argocd-notifications-cm` ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <config-map-name>
+data:
+  service.mattermost: |
+    apiURL: <api-url>
+    apiKey: $newrelic-apiKey
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  newrelic-apiKey: apiKey
+```
+
+3. Copy [Application ID](https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/get-app-other-ids-new-relic-one/#apm)
+4. Create subscription for your NewRelic integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.newrelic: <app-id>
+```
+
+## Templates
+
+* `description` - A high-level description of this deployment, visible in the [Summary](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/apm-overview-page) page and on the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select an individual deployment. Defaults to `message`
+* `changelog` - optional, A summary of what changed in this deployment, visible in the [Deployments](https://docs.newrelic.com/docs/apm/applications-menu/events/deployments-page) page when you select (selected deployment) > Change log
+
+```yaml
+context: |
+  argocdUrl: https://example.com/argocd
+
+template.app-deployed: |
+  message: Application {{.app.metadata.name}} has been healthy.
+  newrelic:
+    description: Application {{.app.metadata.name}} has been healthy
+    changelog: "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}"
+```

--- a/pkg/services/newrelic.go
+++ b/pkg/services/newrelic.go
@@ -1,0 +1,150 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	texttemplate "text/template"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
+	log "github.com/sirupsen/logrus"
+)
+
+type NewrelicOptions struct {
+	ApiKey string `json:"apiKey"`
+	ApiURL string `json:"apiURL"`
+}
+
+type NewrelicNotification struct {
+	Revision    string `json:"revision"`
+	Changelog   string `json:"changelog,omitempty"`
+	Description string `json:"description,omitempty"`
+	User        string `json:"user,omitempty"`
+}
+
+var (
+	ErrMissingConfig = errors.New("config is missing")
+	ErrMissingApiKey = errors.New("apiKey is missing")
+)
+
+func (n *NewrelicNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
+	revision, err := texttemplate.New(name).Funcs(f).Parse(revisionTemplate)
+	if err != nil {
+		return nil, err
+	}
+	changelog, err := texttemplate.New(name).Funcs(f).Parse(n.Changelog)
+	if err != nil {
+		return nil, err
+	}
+	description, err := texttemplate.New(name).Funcs(f).Parse(n.Description)
+	if err != nil {
+		return nil, err
+	}
+
+	commitAuthorTemplate := n.User
+	if commitAuthorTemplate == "" {
+		commitAuthorTemplate = "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}"
+	}
+
+	user, err := texttemplate.New(name).Funcs(f).Parse(commitAuthorTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(notification *Notification, vars map[string]interface{}) error {
+		if notification.Newrelic == nil {
+			notification.Newrelic = &NewrelicNotification{}
+		}
+		var revisionData bytes.Buffer
+		if err := revision.Execute(&revisionData, vars); err != nil {
+			return err
+		}
+		notification.Newrelic.Revision = revisionData.String()
+
+		var changelogData bytes.Buffer
+		if err := changelog.Execute(&changelogData, vars); err != nil {
+			return err
+		}
+		notification.Newrelic.Changelog = changelogData.String()
+
+		var descriptionData bytes.Buffer
+		if err := description.Execute(&descriptionData, vars); err != nil {
+			return err
+		}
+		notification.Newrelic.Description = descriptionData.String()
+
+		var userData bytes.Buffer
+		if err := user.Execute(&userData, vars); err != nil {
+			return err
+		}
+		notification.Newrelic.User = userData.String()
+
+		return nil
+	}, nil
+}
+
+func NewNewrelicService(opts NewrelicOptions) NotificationService {
+	if opts.ApiURL == "" {
+		opts.ApiURL = "https://api.newrelic.com"
+	} else {
+		opts.ApiURL = strings.TrimSuffix(opts.ApiURL, "/")
+	}
+
+	return &newrelicService{opts: opts}
+}
+
+type newrelicService struct {
+	opts NewrelicOptions
+}
+type newrelicDeploymentMarkerRequest struct {
+	Deployment NewrelicNotification `json:"deployment"`
+}
+
+func (s newrelicService) Send(notification Notification, dest Destination) error {
+	if s.opts.ApiKey == "" {
+		return ErrMissingApiKey
+	}
+
+	if notification.Newrelic == nil {
+		return ErrMissingConfig
+	}
+
+	if notification.Newrelic.Description == "" {
+		notification.Newrelic.Description = notification.Message
+	}
+
+	deploymentMarker := newrelicDeploymentMarkerRequest{
+		Deployment: NewrelicNotification{
+			notification.Newrelic.Revision,
+			notification.Newrelic.Changelog,
+			notification.Newrelic.Description,
+			notification.Newrelic.User,
+		},
+	}
+
+	client := &http.Client{
+		Transport: httputil.NewLoggingRoundTripper(
+			httputil.NewTransport(s.opts.ApiURL, false), log.WithField("service", dest.Service)),
+	}
+
+	jsonValue, err := json.Marshal(deploymentMarker)
+	if err != nil {
+		return err
+	}
+
+	markerApi := fmt.Sprintf(s.opts.ApiURL+"/v2/applications/%s/deployments.json", dest.Recipient)
+	req, err := http.NewRequest(http.MethodPost, markerApi, bytes.NewBuffer(jsonValue))
+	if err != nil {
+		log.Errorf("Failed to create deployment marker request: %s", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Api-Key", s.opts.ApiKey)
+
+	_, err = client.Do(req)
+	return err
+}

--- a/pkg/services/newrelic.go
+++ b/pkg/services/newrelic.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	texttemplate "text/template"
 
-	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 	log "github.com/sirupsen/logrus"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 )
 
 type NewrelicOptions struct {

--- a/pkg/services/newrelic.go
+++ b/pkg/services/newrelic.go
@@ -36,11 +36,17 @@ func (n *NewrelicNotification) GetTemplater(name string, f texttemplate.FuncMap)
 	if err != nil {
 		return nil, err
 	}
-	changelog, err := texttemplate.New(name).Funcs(f).Parse(n.Changelog)
+	description, err := texttemplate.New(name).Funcs(f).Parse(n.Description)
 	if err != nil {
 		return nil, err
 	}
-	description, err := texttemplate.New(name).Funcs(f).Parse(n.Description)
+
+	changelogTemplate := n.Changelog
+	if changelogTemplate == "" {
+		changelogTemplate = "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Message}}"
+	}
+
+	changelog, err := texttemplate.New(name).Funcs(f).Parse(changelogTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/newrelic_test.go
+++ b/pkg/services/newrelic_test.go
@@ -1,0 +1,173 @@
+package services
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTemplater_Newrelic(t *testing.T) {
+	n := Notification{
+		Newrelic: &NewrelicNotification{
+			Changelog:   "Added: /v2/deployments.rb",
+			Description: "Deployment finished for {{.app.metadata.name}}. Visit: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+			User:        "{{.context.user}}",
+		},
+	}
+
+	templater, err := n.GetTemplater("newrelic", template.FuncMap{})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var notification Notification
+
+	err = templater(&notification, map[string]interface{}{
+		"context": map[string]interface{}{
+			"argocdUrl": "https://example.com",
+			"user":      "somebot",
+		},
+		"app": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "argocd-notifications",
+			},
+			"status": map[string]interface{}{
+				"operationState": map[string]interface{}{
+					"syncResult": map[string]interface{}{
+						"revision": "0123456789",
+					},
+				},
+			},
+		},
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "0123456789", notification.Newrelic.Revision)
+	assert.Equal(t, "Added: /v2/deployments.rb", notification.Newrelic.Changelog)
+	assert.Equal(t, "Deployment finished for argocd-notifications. Visit: https://example.com/applications/argocd-notifications", notification.Newrelic.Description)
+	assert.Equal(t, "somebot", notification.Newrelic.User)
+}
+
+func TestSend_Newrelic(t *testing.T) {
+	t.Run("revision deployment marker", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := ioutil.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, r.URL.Path, "/v2/applications/123456789/deployments.json")
+			assert.Equal(t, r.Header["Content-Type"], []string{"application/json"})
+			assert.Equal(t, r.Header["Api-Key"], []string{"NRAK-5F2FIVA5UTA4FFDD11XCXVA7WPJ"})
+
+			assert.JSONEq(t, `{
+				"deployment": {
+					"revision": "2027ed5",
+					"description": "message",
+					"user": "datanerd@example.com"
+				}
+			}`, string(b))
+		}))
+		defer ts.Close()
+
+		service := NewNewrelicService(NewrelicOptions{
+			ApiKey: "NRAK-5F2FIVA5UTA4FFDD11XCXVA7WPJ",
+			ApiURL: ts.URL,
+		})
+		err := service.Send(Notification{
+			Message: "message",
+			Newrelic: &NewrelicNotification{
+				Revision: "2027ed5",
+				User:     "datanerd@example.com",
+			},
+		}, Destination{
+			Service:   "newrelic",
+			Recipient: "123456789",
+		})
+
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+
+	t.Run("complete deployment marker", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := ioutil.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, r.URL.Path, "/v2/applications/123456789/deployments.json")
+			assert.Equal(t, r.Header["Content-Type"], []string{"application/json"})
+			assert.Equal(t, r.Header["Api-Key"], []string{"NRAK-5F2FIVA5UTA4FFDD11XCXVA7WPJ"})
+
+			assert.JSONEq(t, `{
+				"deployment": {
+					"revision": "2027ed5",
+					"changelog": "Added: /v2/deployments.rb, Removed: None",
+					"description": "Added a deployments resource to the v2 API",
+					"user": "datanerd@example.com"
+				}
+			}`, string(b))
+		}))
+		defer ts.Close()
+
+		service := NewNewrelicService(NewrelicOptions{
+			ApiKey: "NRAK-5F2FIVA5UTA4FFDD11XCXVA7WPJ",
+			ApiURL: ts.URL,
+		})
+		err := service.Send(Notification{
+			Message: "message",
+			Newrelic: &NewrelicNotification{
+				Revision:    "2027ed5",
+				Changelog:   "Added: /v2/deployments.rb, Removed: None",
+				Description: "Added a deployments resource to the v2 API",
+				User:        "datanerd@example.com",
+			},
+		}, Destination{
+			Service:   "newrelic",
+			Recipient: "123456789",
+		})
+
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+
+	t.Run("missing config", func(t *testing.T) {
+		service := NewNewrelicService(NewrelicOptions{
+			ApiKey: "NRAK-5F2FIVA5UTA4FFDD11XCXVA7WPJ",
+		})
+		err := service.Send(Notification{
+			Message: "message",
+		}, Destination{
+			Service:   "newrelic",
+			Recipient: "123456789",
+		})
+
+		if assert.Error(t, err) {
+			assert.Equal(t, err, ErrMissingConfig)
+		}
+	})
+
+	t.Run("missing apiKey", func(t *testing.T) {
+		service := NewNewrelicService(NewrelicOptions{})
+		err := service.Send(Notification{
+			Message: "message",
+		}, Destination{
+			Service:   "newrelic",
+			Recipient: "123456789",
+		})
+
+		if assert.Error(t, err) {
+			assert.Equal(t, err, ErrMissingApiKey)
+		}
+	})
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -24,6 +24,7 @@ type Notification struct {
 	Alertmanager *AlertmanagerNotification `json:"alertmanager,omitempty"`
 	GoogleChat   *GoogleChatNotification   `json:"googlechat,omitempty"`
 	Pagerduty    *PagerDutyNotification    `json:"pagerduty,omitempty"`
+	Newrelic     *NewrelicNotification     `json:"newrelic,omitempty"`
 }
 
 // Destinations holds notification destinations group by trigger
@@ -94,6 +95,10 @@ func (n *Notification) GetTemplater(name string, f texttemplate.FuncMap) (Templa
 
 	if n.Pagerduty != nil {
 		sources = append(sources, n.Pagerduty)
+	}
+
+	if n.Newrelic != nil {
+		sources = append(sources, n.Newrelic)
 	}
 
 	return n.getTemplater(name, f, sources)
@@ -192,6 +197,12 @@ func NewService(serviceType string, optsData []byte) (NotificationService, error
 			return nil, err
 		}
 		return NewPagerdutyService(opts), nil
+	case "newrelic":
+		var opts NewrelicOptions
+		if err := yaml.Unmarshal(optsData, &opts); err != nil {
+			return nil, err
+		}
+		return NewNewrelicService(opts), nil
 	default:
 		return nil, fmt.Errorf("service type '%s' is not supported", serviceType)
 	}


### PR DESCRIPTION
Hi folks,

My company is in the process of rolling out New Relic internally and I saw an opportunity for adding a new notification service for it to integrate with its [Deployment Marker](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/record-monitor-deployments/) functionality.

Not sure if the contributing process involving opening up an issue first, etc, so just let me know if changes are need to be made.

Also, pretty new to the Argoproj codebase, so let me know if I missed any aspect of adding a new notification service, or if there are any other considerations/suggestions. Haven't tested e2e, not sure the best way of doing so within this codebase or integrated with the ArgoCD one.

Issue: #93 