### PR TITLE
feat: add Google Chat thread support

### DIFF
--- a/docs/services/googlechat.md
+++ b/docs/services/googlechat.md
@@ -79,3 +79,14 @@ template.app-sync-succeeded: |
 ```
 
 The card message can be written in JSON too.
+
+## Chat Threads
+
+It is possible send both simple text and card messages in a chat thread by specifying a unique key for the thread. The thread key can be defined as follows:
+
+```yaml
+template.app-sync-succeeded: |
+  message: The app {{ .app.metadata.name }} has succesfully synced!
+  googlechat:
+    threadKey: {{ .app.metadata.name }}
+```


### PR DESCRIPTION
Support posting messages to a chat thread based on an arbitrary key.

Example threads:
![image](https://user-images.githubusercontent.com/814148/173931257-f5eed1c6-b193-4f5e-a154-87368558e3f0.png)

See Chat API create message [query parameters](https://developers.google.com/chat/api/reference/rest/v1/spaces.messages/create#query-parameters).
