### PR TITLE
docs: fixes the YAML codefence for `Slack` notification service

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -56,23 +56,21 @@ The Slack notification service configuration includes following settings:
 
 1. Annotation with more than one trigger multiple of destinations and recipients
 
-      ```yaml
-      apiVersion: argoproj.io/v1alpha1
-      kind: Application
-      metadata:
-      annotations:
-        notifications.argoproj.io/subscriptions: |
-          - trigger: [on-scaling-replica-set, on-rollout-updated, on-rollout-step-completed]
-            destinations:
-              - service: slack
-                recipients: [my-channel-1, my-channel-2]
-              - service: email
-                recipients: [recipient-1, recipient-2, recipient-3 ]
-          - trigger: [on-rollout-aborted, on-analysis-run-failed, on-analysis-run-error]
-            destinations:
-              - service: slack
-                recipients: [my-channel-21, my-channel-22]
-      ```
+        apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        metadata:
+        annotations:
+          notifications.argoproj.io/subscriptions: |
+            - trigger: [on-scaling-replica-set, on-rollout-updated, on-rollout-step-completed]
+              destinations:
+                - service: slack
+                  recipients: [my-channel-1, my-channel-2]
+                - service: email
+                  recipients: [recipient-1, recipient-2, recipient-3 ]
+            - trigger: [on-rollout-aborted, on-analysis-run-failed, on-analysis-run-error]
+              destinations:
+                - service: slack
+                  recipients: [my-channel-21, my-channel-22]
 
 ## Templates
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -32,18 +32,18 @@ The Slack notification service configuration includes following settings:
         apiVersion: v1
         kind: Secret
         metadata:
-        name: <secret-name>
+          name: <secret-name>
         stringData:
-        slack-token: <Oauth-access-token>
+          slack-token: <Oauth-access-token>
 
 1. Define service type slack in data section of `argocd-notifications-cm` configmap:
 
         apiVersion: v1
         kind: ConfigMap
         metadata:
-        name: <config-map-name>
+          name: <config-map-name>
         data:
-        service.slack: |
+          service.slack: |
             token: $slack-token
 
 1. Add annotation in application yaml file to enable notifications for specific argocd app
@@ -51,7 +51,7 @@ The Slack notification service configuration includes following settings:
         apiVersion: argoproj.io/v1alpha1
         kind: Application
         metadata:
-        annotations:
+          annotations:
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: my_channel
 
 1. Annotation with more than one trigger multiple of destinations and recipients
@@ -59,18 +59,18 @@ The Slack notification service configuration includes following settings:
         apiVersion: argoproj.io/v1alpha1
         kind: Application
         metadata:
-        annotations:
-          notifications.argoproj.io/subscriptions: |
-            - trigger: [on-scaling-replica-set, on-rollout-updated, on-rollout-step-completed]
-              destinations:
-                - service: slack
-                  recipients: [my-channel-1, my-channel-2]
-                - service: email
-                  recipients: [recipient-1, recipient-2, recipient-3 ]
-            - trigger: [on-rollout-aborted, on-analysis-run-failed, on-analysis-run-error]
-              destinations:
-                - service: slack
-                  recipients: [my-channel-21, my-channel-22]
+          annotations:
+            notifications.argoproj.io/subscriptions: |
+              - trigger: [on-scaling-replica-set, on-rollout-updated, on-rollout-step-completed]
+                destinations:
+                  - service: slack
+                    recipients: [my-channel-1, my-channel-2]
+                  - service: email
+                    recipients: [recipient-1, recipient-2, recipient-3 ]
+              - trigger: [on-rollout-aborted, on-analysis-run-failed, on-analysis-run-error]
+                destinations:
+                  - service: slack
+                    recipients: [my-channel-21, my-channel-22]
 
 ## Templates
 


### PR DESCRIPTION
Related to [#80], borked YAML was introduced in #65.
Codefences in lists must be created with indentation, otherwise they'll be rendered as inline code
![image](https://user-images.githubusercontent.com/1681525/176141528-da4e4512-56a8-4c79-8ceb-4441016eb9d4.png)


Signed-off-by: Ole-Martin Bratteng <1681525+omBratteng@users.noreply.github.com>