### PR TITLE
Allow user to skip verification on self-signed certs

### DIFF
--- a/docs/services/webhook.md
+++ b/docs/services/webhook.md
@@ -1,7 +1,18 @@
-## Configuration
+# Webhook
 
 The webhook notification service allows sending a generic HTTP request using the templatized request body and URL.
 Using Webhook you might trigger a Jenkins job, update Github commit status.
+
+## Parameters
+
+The Webhook notification service configuration includes following settings:
+
+- `url` - the url to send the webhook to
+- `headers` - optional, the headers to pass along with the webhook
+- `basicAuth` - optional, the basic authentication to pass along with the webook
+- `insecureSkipVerify` - optional bool, true or false
+
+## Configuration
 
 Use the following steps to configure webhook:
 
@@ -21,6 +32,7 @@ data:
     basicAuth: #optional username password
       username: <username>
       password: <api-key>
+    insecureSkipVerify: true #optional bool
 ```
 
 2 Define template that customizes webhook request method, path and body:

--- a/pkg/services/webhook.go
+++ b/pkg/services/webhook.go
@@ -77,9 +77,10 @@ type BasicAuth struct {
 }
 
 type WebhookOptions struct {
-	URL       string     `json:"url"`
-	Headers   []Header   `json:"headers"`
-	BasicAuth *BasicAuth `json:"basicAuth"`
+	URL                string     `json:"url"`
+	Headers            []Header   `json:"headers"`
+	BasicAuth          *BasicAuth `json:"basicAuth"`
+	InsecureSkipVerify bool       `json:"insecureSkipVerify"`
 }
 
 func NewWebhookService(opts WebhookOptions) NotificationService {
@@ -154,7 +155,7 @@ func (r *request) execute(service *webhookService) (*http.Response, error) {
 
 	client := http.Client{
 		Transport: httputil.NewLoggingRoundTripper(
-			httputil.NewTransport(r.url, false),
+			httputil.NewTransport(r.url, service.opts.InsecureSkipVerify),
 			log.WithField("service", r.destService)),
 	}
 

--- a/pkg/services/webhook_test.go
+++ b/pkg/services/webhook_test.go
@@ -23,9 +23,10 @@ func TestWebhook_SuccessfullySendsNotification(t *testing.T) {
 	defer server.Close()
 
 	service := NewWebhookService(WebhookOptions{
-		BasicAuth: &BasicAuth{Username: "testUsername", Password: "testPassword"},
-		URL:       server.URL,
-		Headers:   []Header{{Name: "testHeader", Value: "testHeaderValue"}},
+		BasicAuth:          &BasicAuth{Username: "testUsername", Password: "testPassword"},
+		URL:                server.URL,
+		Headers:            []Header{{Name: "testHeader", Value: "testHeaderValue"}},
+		InsecureSkipVerify: true,
 	})
 	err := service.Send(
 		Notification{


### PR DESCRIPTION
The generic webhook is hardcoded to not skip insecure. I would like to be able to specify this as a webhook option.