### PR TITLE
Make the Github's repoURL and revision paths configurable

### DIFF
--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -58,15 +58,19 @@ metadata:
 
 ![](https://user-images.githubusercontent.com/18019529/108520497-168ce180-730e-11eb-93cb-b0b91f99bdc5.png)
 
-If the message is set to 140 characters or more, it will be truncate.
-
 ```yaml
 template.app-deployed: |
   message: |
     Application {{.app.metadata.name}} is now running new version of deployments manifests.
   github:
+    repoURLPath: "{{.app.spec.source.repoURL}}"
+    revisionPath: "{{.app.status.operationState.syncResult.revision}}"
     status:
       state: success
       label: "continuous-delivery/{{.app.metadata.name}}"
       targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
 ```
+
+**Notes**:
+- If the message is set to 140 characters or more, it will be truncated.
+- If `github.repoURLPath` and `github.revisionPath` are same as above, they can be omitted.

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -58,3 +58,50 @@ func TestGetTemplater_GitHub(t *testing.T) {
 	assert.Equal(t, "continuous-delivery/argocd-notifications", notification.GitHub.Status.Label)
 	assert.Equal(t, "https://example.com/applications/argocd-notifications", notification.GitHub.Status.TargetURL)
 }
+
+func TestGetTemplater_GitHub_Custom_Resource(t *testing.T) {
+	n := Notification{
+		GitHub: &GitHubNotification{
+			RepoURLPath:  "{{.sync.spec.git.repo}}",
+			RevisionPath: "{{.sync.status.lastSyncedCommit}}",
+			Status: &GitHubStatus{
+				State: "synced",
+				Label: "continuous-delivery/{{.sync.metadata.name}}",
+			},
+		},
+	}
+	templater, err := n.GetTemplater("", template.FuncMap{})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var notification Notification
+	err = templater(&notification, map[string]interface{}{
+		"sync": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "root-sync-test",
+			},
+			"spec": map[string]interface{}{
+				"git": map[string]interface{}{
+					"repo": "https://github.com/argoproj-labs/argocd-notifications.git",
+				},
+			},
+			"status": map[string]interface{}{
+				"lastSyncedCommit": "0123456789",
+			},
+		},
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "{{.sync.spec.git.repo}}", notification.GitHub.RepoURLPath)
+	assert.Equal(t, "{{.sync.status.lastSyncedCommit}}", notification.GitHub.RevisionPath)
+	assert.Equal(t, "https://github.com/argoproj-labs/argocd-notifications.git", notification.GitHub.repoURL)
+	assert.Equal(t, "0123456789", notification.GitHub.revision)
+	assert.Equal(t, "synced", notification.GitHub.Status.State)
+	assert.Equal(t, "continuous-delivery/root-sync-test", notification.GitHub.Status.Label)
+	assert.Equal(t, "", notification.GitHub.Status.TargetURL)
+}


### PR DESCRIPTION
The Github service uses the hard-coded argo spec paths to extract the repo URL and synced revision. To make the notification engine generic, this commit makes the paths configurable. If they're not specified, it falls back to the argo API.

Fixes https://github.com/argoproj/notifications-engine/issues/59

Signed-off-by: Nan Yu nanyu@google.com