### PR TITLE
make the annotation key prefix configurable

### DIFF
--- a/examples/certmanager/README.md
+++ b/examples/certmanager/README.md
@@ -6,6 +6,12 @@ The example demonstrates how Notifications Engine can be used to implement noti
 
 The machinery required for controller implementation is provided by [pkg/controller](../../pkg/controller) and [pkg/api](../../pkg/api) packages.
 
+* You may optionally set the annotation prefix using the `subscriptions.SetAnnotationPrefix` function. This defaults to `"notifications.argoproj.io"`.
+
+```golang
+subscriptions.SetAnnotationPrefix("example.prefix.io")
+```
+
 * The first step is to write the boilerplate code required to get Kubernetes REST config so we can talk to API server.
 
 * Next create `ConfigMap` and `Secret` informers and use it to initialize `api.Factory`:

--- a/examples/certmanager/controller/main.go
+++ b/examples/certmanager/controller/main.go
@@ -34,6 +34,9 @@ func main() {
 	var command = cobra.Command{
 		Use: "controller",
 		Run: func(c *cobra.Command, args []string) {
+			// Optionally set the annotations prefix
+			// subscriptions.SetAnnotationPrefix("example.prefix.io")
+
 			// Get Kubernetes REST Config and current Namespace so we can talk to Kubernetes
 			restConfig, err := clientConfig.ClientConfig()
 			if err != nil {

--- a/pkg/controller/state.go
+++ b/pkg/controller/state.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	notifiedHistoryMaxSize = 100
-	NotifiedAnnotationKey  = "notified." + subscriptions.AnnotationPrefix
 )
 
 func StateItemKey(trigger string, conditionResult triggers.ConditionResult, dest services.Destination) string {
@@ -67,6 +66,7 @@ func (s NotificationsState) SetAlreadyNotified(trigger string, result triggers.C
 func (s NotificationsState) Persist(res metav1.Object) (map[string]string, error) {
 	s.truncate(notifiedHistoryMaxSize)
 
+	notifiedAnnotationKey := subscriptions.NotifiedAnnotationKey()
 	annotations := map[string]string{}
 
 	if res.GetAnnotations() != nil {
@@ -76,13 +76,13 @@ func (s NotificationsState) Persist(res metav1.Object) (map[string]string, error
 	}
 
 	if len(s) == 0 {
-		delete(annotations, NotifiedAnnotationKey)
+		delete(annotations, notifiedAnnotationKey)
 	} else {
 		stateJson, err := json.Marshal(s)
 		if err != nil {
 			return nil, err
 		}
-		annotations[NotifiedAnnotationKey] = string(stateJson)
+		annotations[notifiedAnnotationKey] = string(stateJson)
 	}
 
 	return annotations, nil
@@ -100,8 +100,9 @@ func NewState(val string) NotificationsState {
 }
 
 func NewStateFromRes(res metav1.Object) NotificationsState {
+	notifiedAnnotationKey := subscriptions.NotifiedAnnotationKey()
 	if annotations := res.GetAnnotations(); annotations != nil {
-		return NewState(annotations[NotifiedAnnotationKey])
+		return NewState(annotations[notifiedAnnotationKey])
 	}
 	return NotificationsState{}
 }

--- a/pkg/subscriptions/annotations.go
+++ b/pkg/subscriptions/annotations.go
@@ -10,9 +10,19 @@ import (
 	"github.com/argoproj/notifications-engine/pkg/services"
 )
 
-const (
-	AnnotationPrefix = "notifications.argoproj.io"
+var (
+	annotationPrefix = "notifications.argoproj.io"
 )
+
+// SetAnnotationPrefix sets the annotationPrefix to the provided string.
+// defaults to "notifications.argoproj.io"
+func SetAnnotationPrefix(prefix string) {
+	annotationPrefix = prefix
+}
+
+func NotifiedAnnotationKey() string {
+	return fmt.Sprintf("notified.%s", annotationPrefix)
+}
 
 func parseRecipients(v string) []string {
 	var recipients []string
@@ -26,7 +36,7 @@ func parseRecipients(v string) []string {
 }
 
 func SubscribeAnnotationKey(trigger string, service string) string {
-	return fmt.Sprintf("%s/subscribe.%s.%s", AnnotationPrefix, trigger, service)
+	return fmt.Sprintf("%s/subscribe.%s.%s", annotationPrefix, trigger, service)
 }
 
 type Annotations map[string]string
@@ -51,8 +61,8 @@ type Destination struct {
 }
 
 func (a Annotations) iterate(callback func(trigger string, service string, recipients []string, key string)) {
-	prefix := AnnotationPrefix + "/subscribe."
-	altPrefix := AnnotationPrefix + "/subscriptions"
+	prefix := annotationPrefix + "/subscribe."
+	altPrefix := annotationPrefix + "/subscriptions"
 	var recipients []string
 	for k, v := range a {
 		switch {

--- a/pkg/subscriptions/annotations_test.go
+++ b/pkg/subscriptions/annotations_test.go
@@ -257,3 +257,15 @@ func TestUnsubscribe(t *testing.T) {
 	_, ok := a["notifications.argoproj.io/subscribe.my-trigger.slack"]
 	assert.False(t, ok)
 }
+
+func TestSetAnnotationPrefix(t *testing.T) {
+	origPrefix := annotationPrefix
+	defer func() {
+		annotationPrefix = origPrefix
+	}()
+
+	SetAnnotationPrefix("test.prefix")
+
+	assert.Equal(t, "test.prefix", annotationPrefix)
+	assert.Equal(t, "notified.test.prefix", NotifiedAnnotationKey())
+}


### PR DESCRIPTION
This is intended to make the prefix configurable for projects using this controller which are not in the Argo ecosystem. This allows such projects to use an annotation key that is consistent with the conventions of their project.

Issues: https://github.com/argoproj/notifications-engine/issues/139