### PR TITLE
GitHub Deployment - Allow Automerge configuration

### DIFF
--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -81,5 +81,6 @@ template.app-deployed: |
 **Notes**:
 - If the message is set to 140 characters or more, it will be truncated.
 - If `github.repoURLPath` and `github.revisionPath` are same as above, they can be omitted.
-- By default, github deployments utilize automerge to ensure the requested ref is up to date with the default branch.
+- Automerge is optional and `true` by default for github deployments to ensure the requested ref is up to date with the default branch.
   Setting this option to `false` is required if you would like to deploy older refs in your default branch.
+  For more information see the [Github Deployment API Docs](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment).

--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -75,6 +75,7 @@ template.app-deployed: |
       environmentURL: "https://{{.app.metadata.name}}.example.com"
       logURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
       requiredContexts: []
+      autoMerge: true
 ```
 
 **Notes**:

--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -81,3 +81,5 @@ template.app-deployed: |
 **Notes**:
 - If the message is set to 140 characters or more, it will be truncated.
 - If `github.repoURLPath` and `github.revisionPath` are same as above, they can be omitted.
+- By default, github deployments utilize automerge to ensure the requested ref is up to date with the default branch.
+  Setting this option to `false` is required if you would like to deploy older refs in your default branch.

--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -192,8 +192,8 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 			}
 			notification.GitHub.Deployment.LogURL = logURLData.String()
 
-			notification.GitHub.Deployment.RequiredContexts = g.Deployment.RequiredContexts
 			notification.GitHub.Deployment.AutoMerge = g.Deployment.AutoMerge
+			notification.GitHub.Deployment.RequiredContexts = g.Deployment.RequiredContexts
 		}
 
 		return nil

--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -52,7 +52,7 @@ type GitHubDeployment struct {
 	EnvironmentURL   string   `json:"environmentURL,omitempty"`
 	LogURL           string   `json:"logURL,omitempty"`
 	RequiredContexts []string `json:"requiredContexts"`
-	AutoMerge        bool     `json:"autoMerge,omitempty"`
+	AutoMerge        *bool    `json:"autoMerge,omitempty"`
 }
 
 const (
@@ -192,7 +192,12 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 			}
 			notification.GitHub.Deployment.LogURL = logURLData.String()
 
-			notification.GitHub.Deployment.AutoMerge = g.Deployment.AutoMerge
+			if g.Deployment.AutoMerge == nil {
+				deploymentAutoMergeDefault := true
+				notification.GitHub.Deployment.AutoMerge = &deploymentAutoMergeDefault
+			} else {
+				notification.GitHub.Deployment.AutoMerge = g.Deployment.AutoMerge
+			}
 			notification.GitHub.Deployment.RequiredContexts = g.Deployment.RequiredContexts
 		}
 
@@ -305,7 +310,7 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 				Ref:              &notification.GitHub.revision,
 				Environment:      &notification.GitHub.Deployment.Environment,
 				RequiredContexts: &notification.GitHub.Deployment.RequiredContexts,
-				AutoMerge:        &notification.GitHub.Deployment.AutoMerge,
+				AutoMerge:        notification.GitHub.Deployment.AutoMerge,
 			},
 		)
 		if err != nil {

--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -52,6 +52,7 @@ type GitHubDeployment struct {
 	EnvironmentURL   string   `json:"environmentURL,omitempty"`
 	LogURL           string   `json:"logURL,omitempty"`
 	RequiredContexts []string `json:"requiredContexts"`
+	AutoMerge        bool     `json:"autoMerge,omitempty"`
 }
 
 const (
@@ -192,6 +193,7 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 			notification.GitHub.Deployment.LogURL = logURLData.String()
 
 			notification.GitHub.Deployment.RequiredContexts = g.Deployment.RequiredContexts
+			notification.GitHub.Deployment.AutoMerge = g.Deployment.AutoMerge
 		}
 
 		return nil
@@ -303,6 +305,7 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 				Ref:              &notification.GitHub.revision,
 				Environment:      &notification.GitHub.Deployment.Environment,
 				RequiredContexts: &notification.GitHub.Deployment.RequiredContexts,
+				AutoMerge:        &notification.GitHub.Deployment.AutoMerge,
 			},
 		)
 		if err != nil {

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -157,6 +157,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 	assert.Equal(t, "https://argoproj.github.io", notification.GitHub.Deployment.EnvironmentURL)
 	assert.Equal(t, "https://argoproj.github.io/log", notification.GitHub.Deployment.LogURL)
 	assert.Len(t, notification.GitHub.Deployment.RequiredContexts, 0)
+	assert.Equal(t, false, notification.GitHub.Deployment.AutoMerge)
 }
 
 func TestNewGitHubService_GitHubOptions(t *testing.T) {

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -117,6 +117,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 				EnvironmentURL:   "https://argoproj.github.io",
 				LogURL:           "https://argoproj.github.io/log",
 				RequiredContexts: []string{},
+				AutoMerge:        false,
 			},
 		},
 	}

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -107,6 +107,7 @@ func TestGetTemplater_GitHub_Custom_Resource(t *testing.T) {
 }
 
 func TestGetTemplater_GitHub_Deployment(t *testing.T) {
+	f := false
 	n := Notification{
 		GitHub: &GitHubNotification{
 			RepoURLPath:  "{{.sync.spec.git.repo}}",
@@ -117,7 +118,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 				EnvironmentURL:   "https://argoproj.github.io",
 				LogURL:           "https://argoproj.github.io/log",
 				RequiredContexts: []string{},
-				AutoMerge:        false,
+				AutoMerge:        &f,
 			},
 		},
 	}
@@ -157,7 +158,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 	assert.Equal(t, "https://argoproj.github.io", notification.GitHub.Deployment.EnvironmentURL)
 	assert.Equal(t, "https://argoproj.github.io/log", notification.GitHub.Deployment.LogURL)
 	assert.Len(t, notification.GitHub.Deployment.RequiredContexts, 0)
-	assert.Equal(t, false, notification.GitHub.Deployment.AutoMerge)
+	assert.Equal(t, &f, notification.GitHub.Deployment.AutoMerge)
 }
 
 func TestNewGitHubService_GitHubOptions(t *testing.T) {


### PR DESCRIPTION
Hi there, thanks for adding support for Deployments to the Notifications Engine.  I was testing out the support and ran into issues trying to deploy an older ref from the default branch.  The notifications controller would report an error when merging the default branch into the commit referenced.  Upon reading the docs, it looks like this is the [intended behavior](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment) so it seems reasonable to allow users to disable this feature when they would not like their deployment updated against the default branch. 

This PR was tested against an internal custom ArgoCD build and it resolved our issues with deployments only functioning on the latest commit in a default branch.  

I'm happy to make any required changes, just let me know.  Thanks!