### PR TITLE
Update documentation for Slack options

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -13,7 +13,7 @@ The Slack notification service configuration includes following settings:
 | `icon`               | False        | `string`       | The app icon, e.g. `:robot_face:` or `https://example.com/image.png` |
 | `insecureSkipVerify` | False        | `bool`         | |
 | `sigingSecret`       | False        | `string`       | |
-| `token`              | **True**     | `string`       | The app token |
+| `token`              | **True**     | `string`       | The app's OAuth access token |
 | `username`           | False        | `string`       | The app username |
 
 ## Configuration

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -6,13 +6,15 @@ If you want to send message using incoming webhook, you can use [webhook](./webh
 
 The Slack notification service configuration includes following settings:
 
-* `apiURL` – (optional, `string`) the server url, e.g. https://example.com/api
-* `channels` – (optional, `list[string]`)
-* `icon` – (optional, `string`) the app icon, e.g. :robot_face: or https://example.com/image.png
-* `insecureSkipVerify` – (optional, `bool`)
-* `sigingSecret` – (optional, `string`)
-* `token` – (`string`) the app token
-* `username` – (optional, `string`) the app username
+| **Option**           | **Required** | **Type**       | **Description** |
+| -------------------- | ------------ | -------------- | --------------- |
+| `apiURL`             | False        | `string`       | The server URL, e.g. `https://example.com/api` |
+| `channels`           | False        | `list[string]` | |
+| `icon`               | False        | `string`       | The app icon, e.g. `:robot_face:` or `https://example.com/image.png` |
+| `insecureSkipVerify` | False        | `bool`         | |
+| `sigingSecret`       | False        | `string`       | |
+| `token`              | **True**     | `string`       | The app token |
+| `username`           | False        | `string`       | The app username |
 
 ## Configuration
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -6,11 +6,11 @@ If you want to send message using incoming webhook, you can use [webhook](./webh
 
 The Slack notification service configuration includes following settings:
 
-* `token` - the app token
-* `apiURL` - optional, the server url, e.g. https://example.com/api
-* `username` - optional, the app username
-* `icon` - optional, the app icon, e.g. :robot_face: or https://example.com/image.png
-* `insecureSkipVerify` - optional bool, true or false
+* `token` – (`string`) the app token
+* `apiURL` – (optional, `string`) the server url, e.g. https://example.com/api
+* `username` – (optional, `string`) the app username
+* `icon` – (optional, `string`) the app icon, e.g. :robot_face: or https://example.com/image.png
+* `insecureSkipVerify` – (optional, `bool`)
 
 ## Configuration
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -12,7 +12,7 @@ The Slack notification service configuration includes following settings:
 | `channels`           | False        | `list[string]` |                 | `["my-channel-1", "my-channel-2"]` |
 | `icon`               | False        | `string`       | The app icon.   | `:robot_face:` or `https://example.com/image.png` |
 | `insecureSkipVerify` | False        | `bool`         |                 | `true` |
-| `sigingSecret`       | False        | `string`       |                 | `8f742231b10e8888abcd99yyyzzz85a5` |
+| `signingSecret`       | False        | `string`       |                 | `8f742231b10e8888abcd99yyyzzz85a5` |
 | `token`              | **True**     | `string`       | The app's OAuth access token. | `xoxb-1234567890-1234567890123-5n38u5ed63fgzqlvuyxvxcx6` |
 | `username`           | False        | `string`       | The app username. | `argocd` |
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -6,11 +6,11 @@ If you want to send message using incoming webhook, you can use [webhook](./webh
 
 The Slack notification service configuration includes following settings:
 
-* `token` – (`string`) the app token
 * `apiURL` – (optional, `string`) the server url, e.g. https://example.com/api
-* `username` – (optional, `string`) the app username
 * `icon` – (optional, `string`) the app icon, e.g. :robot_face: or https://example.com/image.png
 * `insecureSkipVerify` – (optional, `bool`)
+* `token` – (`string`) the app token
+* `username` – (optional, `string`) the app username
 
 ## Configuration
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -6,15 +6,15 @@ If you want to send message using incoming webhook, you can use [webhook](./webh
 
 The Slack notification service configuration includes following settings:
 
-| **Option**           | **Required** | **Type**       | **Description** |
-| -------------------- | ------------ | -------------- | --------------- |
-| `apiURL`             | False        | `string`       | The server URL, e.g. `https://example.com/api` |
-| `channels`           | False        | `list[string]` | |
-| `icon`               | False        | `string`       | The app icon, e.g. `:robot_face:` or `https://example.com/image.png` |
-| `insecureSkipVerify` | False        | `bool`         | |
-| `sigingSecret`       | False        | `string`       | |
-| `token`              | **True**     | `string`       | The app's OAuth access token |
-| `username`           | False        | `string`       | The app username |
+| **Option**           | **Required** | **Type**       | **Description** | **Example** |
+| -------------------- | ------------ | -------------- | --------------- | ----------- |
+| `apiURL`             | False        | `string`       | The server URL. | `https://example.com/api` |
+| `channels`           | False        | `list[string]` |                 | |
+| `icon`               | False        | `string`       | The app icon.   | `:robot_face:` or `https://example.com/image.png` |
+| `insecureSkipVerify` | False        | `bool`         |                 | |
+| `sigingSecret`       | False        | `string`       |                 | |
+| `token`              | **True**     | `string`       | The app's OAuth access token. | `xoxb-1234567890-1234567890123-5n38u5ed63fgzqlvuyxvxcx6` |
+| `username`           | False        | `string`       | The app username. | |
 
 ## Configuration
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -7,8 +7,10 @@ If you want to send message using incoming webhook, you can use [webhook](./webh
 The Slack notification service configuration includes following settings:
 
 * `apiURL` – (optional, `string`) the server url, e.g. https://example.com/api
+* `channels` – (optional, `list[string]`)
 * `icon` – (optional, `string`) the app icon, e.g. :robot_face: or https://example.com/image.png
 * `insecureSkipVerify` – (optional, `bool`)
+* `sigingSecret` – (optional, `string`)
 * `token` – (`string`) the app token
 * `username` – (optional, `string`) the app username
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -9,12 +9,12 @@ The Slack notification service configuration includes following settings:
 | **Option**           | **Required** | **Type**       | **Description** | **Example** |
 | -------------------- | ------------ | -------------- | --------------- | ----------- |
 | `apiURL`             | False        | `string`       | The server URL. | `https://example.com/api` |
-| `channels`           | False        | `list[string]` |                 | |
+| `channels`           | False        | `list[string]` |                 | `["my-channel-1", "my-channel-2"]` |
 | `icon`               | False        | `string`       | The app icon.   | `:robot_face:` or `https://example.com/image.png` |
-| `insecureSkipVerify` | False        | `bool`         |                 | |
-| `sigingSecret`       | False        | `string`       |                 | |
+| `insecureSkipVerify` | False        | `bool`         |                 | `true` |
+| `sigingSecret`       | False        | `string`       |                 | `8f742231b10e8888abcd99yyyzzz85a5` |
 | `token`              | **True**     | `string`       | The app's OAuth access token. | `xoxb-1234567890-1234567890123-5n38u5ed63fgzqlvuyxvxcx6` |
-| `username`           | False        | `string`       | The app username. | |
+| `username`           | False        | `string`       | The app username. | `argocd` |
 
 ## Configuration
 


### PR DESCRIPTION
My first attempt of using the Slack service failed with `invalid_auth`, so I thought that this documentation would need to be updated so not everyone need to play the guessing game.