### PR TITLE
Add GitHub Pull Request comments integration

### DIFF
--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -12,7 +12,7 @@ The GitHub notification service changes commit status using [GitHub Apps](https:
 ## Configuration
 
 1. Create a GitHub Apps using https://github.com/settings/apps/new
-2. Change repository permissions to enable write commit statuses and/or deployments
+2. Change repository permissions to enable write commit statuses and/or deployments and/or pull requests comments
 ![2](https://user-images.githubusercontent.com/18019529/108397381-3ca57980-725b-11eb-8d17-5b8992dc009e.png)
 3. Generate a private key, and download it automatically
 ![3](https://user-images.githubusercontent.com/18019529/108397926-d4a36300-725b-11eb-83fe-74795c8c3e03.png)
@@ -75,8 +75,13 @@ template.app-deployed: |
       environmentURL: "https://{{.app.metadata.name}}.example.com"
       logURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
       requiredContexts: []
+    pullRequestComment:
+      content: |
+        Application {{.app.metadata.name}} is now running new version of deployments manifests.
+        See more here: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true
 ```
 
 **Notes**:
 - If the message is set to 140 characters or more, it will be truncated.
 - If `github.repoURLPath` and `github.revisionPath` are same as above, they can be omitted.
+- If `github.pullRequestComment.content` is set to 65536 characters or more, it will be truncated.

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -194,3 +194,47 @@ func TestNewGitHubService_GitHubOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTemplater_Github_PullRequestComment(t *testing.T) {
+	n := Notification{
+		GitHub: &GitHubNotification{
+			RepoURLPath:  "{{.sync.spec.git.repo}}",
+			RevisionPath: "{{.sync.status.lastSyncedCommit}}",
+			PullRequestComment: &GitHubPullRequestComment{
+				Content: "This is a comment",
+			},
+		},
+	}
+	templater, err := n.GetTemplater("", template.FuncMap{})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var notification Notification
+	err = templater(&notification, map[string]interface{}{
+		"sync": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "root-sync-test",
+			},
+			"spec": map[string]interface{}{
+				"git": map[string]interface{}{
+					"repo": "https://github.com/argoproj-labs/argocd-notifications.git",
+				},
+			},
+			"status": map[string]interface{}{
+				"lastSyncedCommit": "0123456789",
+			},
+		},
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "{{.sync.spec.git.repo}}", notification.GitHub.RepoURLPath)
+	assert.Equal(t, "{{.sync.status.lastSyncedCommit}}", notification.GitHub.RevisionPath)
+	assert.Equal(t, "https://github.com/argoproj-labs/argocd-notifications.git", notification.GitHub.repoURL)
+	assert.Equal(t, "0123456789", notification.GitHub.revision)
+	assert.Equal(t, "This is a comment", notification.GitHub.PullRequestComment.Content)
+}


### PR DESCRIPTION
Closes #136

Similarly to #151, this PR adds the integration with Github to allow commenting on a PullRequest.

I tested it working as expected in a custom installation of ArgoCD using the code in this PR for the notification-engine

**Note**: the code in this PR currently **creates a new comment** every time, it does not update the existing one. To me, the possibility to edit the previous comment could be seen as a future improvement