### PR TITLE
docs: Fix case of vendor names

### DIFF
--- a/docs/services/opsgenie.md
+++ b/docs/services/opsgenie.md
@@ -12,8 +12,8 @@ To be able to send notifications with argocd-notifications you have to create an
 8. Give your integration a name, copy the "API key" and safe it somewhere for later
 9. Make sure the checkboxes for "Create and Update Access" and "enable" are selected, disable the other checkboxes to remove unnecessary permissions
 10. Click "Safe Integration" at the bottom
-11. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the us/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (european api). 
-12. You are finished with configuring opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the opsgenie integration in the `argocd-notifications-secret` secret. 
+11. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the US/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (European API). 
+12. You are finished with configuring opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argocd-notifications-secret` secret. 
 
 ```yaml
 apiVersion: v1

--- a/docs/services/pagerduty.md
+++ b/docs/services/pagerduty.md
@@ -1,17 +1,17 @@
-# Pagerduty
+# PagerDuty
 
 ## Parameters
 
-The Pagerduty notification service is used to create pagerduty incidents and requires specifying the following settings:
+The PagerDuty notification service is used to create PagerDuty incidents and requires specifying the following settings:
 
-* `pagerdutyToken` - the pagerduty auth token
+* `pagerdutyToken` - the PagerDuty auth token
 * `from` - email address of a valid user associated with the account making the request.
 * `serviceID` - The ID of the resource.
 
 
 ## Example
 
-The following snippet contains sample Pagerduty service configuration:
+The following snippet contains sample PagerDuty service configuration:
 
 ```yaml
 apiVersion: v1
@@ -35,7 +35,7 @@ data:
 
 ## Template
 
-[Notification templates](../templates.md) support specifying subject for pagerduty notifications:
+[Notification templates](../templates.md) support specifying subject for PagerDuty notifications:
 
 ```yaml
 apiVersion: v1
@@ -62,5 +62,5 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerduty: "<serviceID for Pagerduty>"
+    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerduty: "<serviceID for PagerDuty>"
 ```

--- a/docs/services/pagerduty_v2.md
+++ b/docs/services/pagerduty_v2.md
@@ -74,5 +74,5 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   annotations:
-    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerdutyv2: "<serviceID for Pagerduty>"
+    notifications.argoproj.io/subscribe.on-rollout-aborted.pagerdutyv2: "<serviceID for PagerDuty>"
 ```


### PR DESCRIPTION
This PR fixes the case of two vendor names - PagerDuty and Opsgenie - in the docs just to make sure they're formal and aligned to those vendor's branding.

These don't look to be autogenerated in this repo, but best I understand get defined here and "pulled down" into CD and Rollouts?

This should help support upstream doc fix in https://github.com/argoproj/argo-cd/pull/16233.  May require downstream PRs in both Argo CD and Argo Rollouts, lest the codegen steps in those fail (?).