### PR TITLE
fix(ci): Download Go modules before linting to resolve typecheck errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
+      - run: go mod download
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
Noticed some reports on TypeCheck errors in https://github.com/golangci/golangci-lint-action/issues/902. These are similar to what we see with https://github.com/argoproj/notifications-engine/pull/256, https://github.com/argoproj/notifications-engine/pull/255, and https://github.com/argoproj/notifications-engine/pull/254.

This is a small change to download the Go modules prior to listing to intend to elevate the TypeCheck problems. The pipeline doesn't currently use cache and the mods download quite quickly, though over time this could be changed to use cache.