### PR TITLE
feat(awssqs): Support sending messages to SQS FIFO queues

### DIFF
--- a/docs/services/awssqs.md
+++ b/docs/services/awssqs.md
@@ -1,8 +1,8 @@
-# AWS SQS 
+# AWS SQS
 
 ## Parameters
 
-This notification service is capable of sending simple messages to AWS SQS queue. 
+This notification service is capable of sending simple messages to AWS SQS queue.
 
 * `queue` - name of the queue you are intending to send messages to. Can be overridden with target destination annotation.
 * `region` - region of the sqs queue can be provided via env variable AWS_DEFAULT_REGION
@@ -103,4 +103,17 @@ data:
       send: [deployment-ready]
     - oncePer: obj.metadata.annotations["generation"]
 
+```
+
+## FIFO SQS Queues
+
+FIFO queues require a [MessageGroupId](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#SQS-SendMessage-request-MessageGroupId) to be sent along with every message, every message with a matching MessageGroupId will be processed one by one in order.
+
+To send to a FIFO SQS Queue you must include a `messageGroupId` in the template such as in the example below:
+
+```yaml
+template.deployment-ready: |
+  message: |
+    Deployment {{.obj.metadata.name}} is ready!
+  messageGroupId: {{.obj.metadata.name}}-deployment
 ```

--- a/pkg/services/awssqs_test.go
+++ b/pkg/services/awssqs_test.go
@@ -20,6 +20,7 @@ func TestGetTemplater_AwsSqs(t *testing.T) {
 			MessageAttributes: map[string]string{
 				"attributeKey": "{{.messageAttributeValue}}",
 			},
+			MessageGroupId: "{{.messageGroupId}}",
 		},
 	}
 
@@ -33,6 +34,7 @@ func TestGetTemplater_AwsSqs(t *testing.T) {
 	err = templater(&notification, map[string]interface{}{
 		"message":               "abcdef",
 		"messageAttributeValue": "123456",
+		"messageGroupId":        "a1b2c3",
 	})
 
 	if !assert.NoError(t, err) {
@@ -42,6 +44,7 @@ func TestGetTemplater_AwsSqs(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"attributeKey": "123456",
 	}, notification.AwsSqs.MessageAttributes)
+	assert.Equal(t, "a1b2c3", notification.AwsSqs.MessageGroupId)
 }
 
 func TestSend_AwsSqs(t *testing.T) {


### PR DESCRIPTION
This should allow the awssqs service to send messages to FIFO SQS queues which require a MessageGroupId to be set.