### PR TITLE
Add option for Telegram to use a thread id when posting notification

### DIFF
--- a/docs/services/telegram.md
+++ b/docs/services/telegram.md
@@ -33,3 +33,12 @@ metadata:
   annotations:
     notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: -1000000000000
 ```
+
+If your private chat contains threads, you can optionally specify a thread id by seperating it with a `|`:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: -1000000000000|2
+```

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,5 @@ require (
 )
 
 replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.14.0
+
+replace github.com/go-telegram-bot-api/telegram-bot-api/v5 => github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYr
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf h1:a7VKhbjKYPO8twGy/1AxMpM2Fp0qT7bf25fmCVMVu4s=
+github.com/OvyFlash/telegram-bot-api/v5 v5.0.0-20240108230938-63e5c59035bf/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/PagerDuty/go-pagerduty v1.7.0 h1:S1NcMKECxT5hJwV4VT+QzeSsSiv4oWl1s2821dUqG/8=
 github.com/PagerDuty/go-pagerduty v1.7.0/go.mod h1:PuFyJKRz1liIAH4h5KVXVD18Obpp1ZXRdxHvmGXooro=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
@@ -174,8 +176,6 @@ github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=

--- a/pkg/services/telegram.go
+++ b/pkg/services/telegram.go
@@ -26,7 +26,9 @@ func (s telegramService) Send(notification Notification, dest Destination) error
 	}
 
 	if strings.HasPrefix(dest.Recipient, "-") {
-		chatID, err := strconv.ParseInt(dest.Recipient, 10, 64)
+		chatChannel := strings.Split(dest.Recipient, "|")
+
+		chatID, err := strconv.ParseInt(chatChannel[0], 10, 64)
 		if err != nil {
 			return err
 		}
@@ -34,6 +36,14 @@ func (s telegramService) Send(notification Notification, dest Destination) error
 		// Init message with ParseMode is 'Markdown'
 		msg := tgbotapi.NewMessage(chatID, notification.Message)
 		msg.ParseMode = "Markdown"
+
+		if len(chatChannel) > 1 {
+			threadID, err := strconv.Atoi(chatChannel[1])
+			if err != nil {
+				return err
+			}
+			msg.MessageThreadID = threadID
+		}
 
 		_, err = bot.Send(msg)
 		if err != nil {

--- a/pkg/services/telegram_test.go
+++ b/pkg/services/telegram_test.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+func TestBuildTelegramMessageOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		notification Notification
+		dest         Destination
+		want         *tgbotapi.MessageConfig
+		wantErr      bool
+	}{
+		{
+			name:         "Message to chat",
+			notification: Notification{Message: "Test message"},
+			dest:         Destination{Recipient: "-123456"},
+			want:         &tgbotapi.MessageConfig{Text: "Test message", BaseChat: tgbotapi.BaseChat{ChatConfig: tgbotapi.ChatConfig{ChatID: -123456}, MessageThreadID: 0}, ParseMode: "Markdown"},
+			wantErr:      false,
+		},
+		{
+			name:         "Message to chat with thread",
+			notification: Notification{Message: "Test message"},
+			dest:         Destination{Recipient: "-123456|1"},
+			want:         &tgbotapi.MessageConfig{Text: "Test message", BaseChat: tgbotapi.BaseChat{ChatConfig: tgbotapi.ChatConfig{ChatID: -123456}, MessageThreadID: 1}, ParseMode: "Markdown"},
+			wantErr:      false,
+		},
+		{
+			name:         "Message to channel",
+			notification: Notification{Message: "Test message"},
+			dest:         Destination{Recipient: "123456"},
+			want:         &tgbotapi.MessageConfig{Text: "Test message", BaseChat: tgbotapi.BaseChat{ChatConfig: tgbotapi.ChatConfig{ChannelUsername: "@123456"}}, ParseMode: "Markdown"},
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildTelegramMessageOptions(tt.notification, tt.dest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildTelegramMessageOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildTelegramMessageOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This also migrates the go library to the one from OvyFlash, since the current one seems to be no longer maintained:
https://github.com/go-telegram-bot-api/telegram-bot-api/issues/695

