### PR TITLE
feat(opsgenie): Add support for setting alias in Opsgenie notification

### DIFF
--- a/docs/services/opsgenie.md
+++ b/docs/services/opsgenie.md
@@ -7,14 +7,22 @@ To be able to send notifications with argocd-notifications you have to create an
 3. Click "Teams" in the Menu on the left
 4. Select the team that you want to notify
 5. In the teams configuration menu select "Integrations"
-6. click "Add Integration" in the top right corner
+6. Click "Add Integration" in the top right corner
 7. Select "API" integration
 8. Give your integration a name, copy the "API key" and safe it somewhere for later
-9. Make sure the checkboxes for "Create and Update Access" and "enable" are selected, disable the other checkboxes to remove unnecessary permissions
-10. Click "Safe Integration" at the bottom
-11. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the US/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (European API). 
-12. You are finished with configuring Opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argocd-notifications-secret` secret.
+9. Click "Edit" in the integration settings
+10. Make sure the checkbox for "Create and Update Access" is selected, disable the other checkboxes to remove unnecessary permissions
+11. Click "Save" at the bottom
+12. Click "Turn on integration" in the top right corner
+13. Check your browser for the correct server apiURL. If it is "app.opsgenie.com" then use the US/international api url `api.opsgenie.com` in the next step, otherwise use `api.eu.opsgenie.com` (European API). 
+14. You are finished with configuring Opsgenie. Now you need to configure argocd-notifications. Use the apiUrl, the team name and the apiKey to configure the Opsgenie integration in the `argocd-notifications-secret` secret.
+15. You can find the example `argocd-notifications-cm` configuration at the below.
 
+| **Option**    | **Required** | **Type** | **Description**                                                                                          | **Example**                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `description` | True         | `string` | Description field of the alert that is generally used to provide a detailed information about the alert. | `Hello from Argo CD!`            |
+| `priority`    | False        | `string` | Priority level of the alert. Possible values are P1, P2, P3, P4 and P5. Default value is P3.             | `P1`                             |
+| `alias`       | False        | `string` | Client-defined identifier of the alert, that is also the key element of Alert De-Duplication.            | `Life is too short for no alias` |
 
 ```yaml
 apiVersion: v1
@@ -26,4 +34,29 @@ data:
     apiUrl: <api-url>
     apiKeys:
       <your-team>: <integration-api-key>
+  template.opsgenie: |
+    message: |
+      [Argo CD] Application {{.app.metadata.name}} has a problem.
+    opsgenie:
+      description: |
+        Application: {{.app.metadata.name}}
+        Health Status: {{.app.status.health.status}}
+        Operation State Phase: {{.app.status.operationState.phase}}
+        Sync Status: {{.app.status.sync.status}}
+      priority: P1
+      alias: {{.app.metadata.name}}
+  trigger.on-a-problem: |
+    - description: Application has a problem.
+      send:
+      - opsgenie
+      when: app.status.health.status == 'Degraded' or app.status.operationState.phase in ['Error', 'Failed'] or app.status.sync.status == 'Unknown'
+```
+
+16. Add annotation in application yaml file to enable notifications for specific Argo CD app.
+```yaml
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    annotations:
+      notifications.argoproj.io/subscribe.on-a-problem.opsgenie: <your-team>
 ```

--- a/pkg/services/opsgenie_test.go
+++ b/pkg/services/opsgenie_test.go
@@ -73,11 +73,23 @@ func TestOpsgenieNotification_GetTemplater(t *testing.T) {
 		assert.Equal(t, "Test alias: bar", mockNotification.Opsgenie.Alias)
 	})
 
-	t.Run("InvalidTemplate", func(t *testing.T) {
+	t.Run("InvalidTemplateDescription", func(t *testing.T) {
 		// Create a new OpsgenieNotification instance with an invalid description template
 		notification := OpsgenieNotification{
 			Description: "{{.invalid", // Invalid template syntax
-			Alias:       "{{.invalid",
+		}
+
+		// Call the GetTemplater method with the invalid template
+		_, err := notification.GetTemplater(name, f)
+
+		// Assert that an error occurred during the call
+		assert.Error(t, err)
+	})
+
+	t.Run("InvalidTemplateAlias", func(t *testing.T) {
+		// Create a new OpsgenieNotification instance with an invalid alias template
+		notification := OpsgenieNotification{
+			Alias: "{{.invalid", // Invalid template syntax
 		}
 
 		// Call the GetTemplater method with the invalid template
@@ -95,13 +107,9 @@ func TestOpsgenie_SendNotification_MissingAPIKey(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Replace the HTTP client in the Opsgenie service with a mock client
-	mockClient := &http.Client{
-		Transport: &http.Transport{},
-	}
-	service := NewOpsgenieServiceWithClient(OpsgenieOptions{
+	service := NewOpsgenieService(OpsgenieOptions{
 		ApiUrl:  server.URL,
-		ApiKeys: map[string]string{}}, mockClient)
+		ApiKeys: map[string]string{}})
 
 	// Prepare test data
 	recipient := "testRecipient"
@@ -123,7 +131,7 @@ func TestOpsgenie_SendNotification_MissingAPIKey(t *testing.T) {
 
 	// Assert the result for missing API Key
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "No API key configured for recipient")
+	assert.Contains(t, err.Error(), "no API key configured for recipient testRecipient")
 }
 func TestOpsgenie_SendNotification_WithMessageOnly(t *testing.T) {
 	// Create a mock HTTP server


### PR DESCRIPTION
This PR adds support for setting the alias field in the Opsgenie notifications. 

We are teammates with who created this [PR](https://github.com/argoproj/notifications-engine/pull/267). We are planning to update the Opsgenie documentation after this is merged. 