### PR TITLE
fix: Correction in Rocket.chat documentation

### DIFF
--- a/docs/services/rocketchat.md
+++ b/docs/services/rocketchat.md
@@ -4,7 +4,7 @@
 
 The Rocket.Chat notification service configuration includes following settings:
 
-* `email` - the Rocker.Chat user's email
+* `email` - the Rocker.Chat user's SAMAccountName
 * `password` - the Rocker.Chat user's password
 * `alias` - optional alias that should be used to post message
 * `icon` - optional message icon
@@ -25,7 +25,7 @@ The Rocket.Chat notification service configuration includes following settings:
 4. Copy username and password that you was created for bot user
 5. Create a public or private channel, or a team, for this example `my_channel`
 6. Add your bot to this channel **otherwise it won't work**
-7. Store email and password in argocd_notifications-secret Secret
+7. Store email and password in argocd-notifications-secret Secret
  
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Fixed the documentation issue in Rocket.chat that was causing issues with notification setup - changed the rocketchat-email to be the user's SAMAccountName, not the user's email address.