### PR TITLE
Allow GitHub InstallationID override

### DIFF
--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -121,13 +121,29 @@ func TestSend_GitHubService_BadURL(t *testing.T) {
 	assert.ErrorContains(t, e, "does not have a `/`")
 }
 
+func TestGetTemplater_GithubNotification_MissingInstallationID(t *testing.T) {
+	e := gitHubService{}.Send(
+		Notification{
+			GitHub: &GitHubNotification{
+				repoURL: "https://github.com/",
+			},
+		},
+		Destination{
+			Service:   "test",
+			Recipient: "test",
+		},
+	)
+	assert.ErrorContains(t, e, "Installation ID not found")
+}
+
 func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 	f := false
 	tr := true
 	n := Notification{
 		GitHub: &GitHubNotification{
-			RepoURLPath:  "{{.sync.spec.git.repo}}",
-			RevisionPath: "{{.sync.status.lastSyncedCommit}}",
+			InstallationID: "12345",
+			RepoURLPath:    "{{.sync.spec.git.repo}}",
+			RevisionPath:   "{{.sync.status.lastSyncedCommit}}",
 			Deployment: &GitHubDeployment{
 				Reference:            "v0.0.1",
 				State:                "success",
@@ -167,6 +183,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 		return
 	}
 
+	assert.Equal(t, "12345", notification.GitHub.InstallationID)
 	assert.Equal(t, "{{.sync.spec.git.repo}}", notification.GitHub.RepoURLPath)
 	assert.Equal(t, "{{.sync.status.lastSyncedCommit}}", notification.GitHub.RevisionPath)
 	assert.Equal(t, "https://github.com/argoproj-labs/argocd-notifications.git", notification.GitHub.repoURL)


### PR DESCRIPTION
This likely needs more work, but I wanted some input before digging deeper into it. 

Right now, we can use a single GitHub App Installation for these notifications; if you have other GitHub organizations which have a unique installation ID, you cannot use the GitHub service for all of them. 

There are a couple of existing solutions here:
* Use a webhook to manage PR updates, deployments, etc for smaller organizations 
* Consolidate app repositories into a single GitHub organization

I am proposing a reasonably simple change that would allow the Installation ID to be passed into the template to override the default Installation ID. This would require the installation ID to be attached to an ArgoCD application as info metadata or custom templates for each GitHub organization.  

This will still use a single GitHub App, but it could be installed in multiple GitHub organizations.