### PR TITLE
feat(slack): Support set username and icon from template in slack

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -117,6 +117,35 @@ template.app-sync-status: |
       }]
 ```
 
+If you want to specify an icon and username for each message, you can specify values for `username` and `icon` in the `slack` field.
+For icon you can specify emoji and image URL, just like in the service definition.
+If you set `username` and `icon` in template, the values set in template will be used even if values are specified in the service definition.
+
+```yaml
+template.app-sync-status: |
+  message: |
+    Application {{.app.metadata.name}} sync is {{.app.status.sync.status}}.
+    Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  slack:
+    username: "testbot"
+    icon: https://example.com/image.png
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+```
+
 The messages can be aggregated to the slack threads by grouping key which can be specified in a `groupingKey` string field under `slack` field.
 `groupingKey` is used across each template and works independently on each slack channel.
 When multiple applications will be updated at the same time or frequently, the messages in slack channel can be easily read by aggregating with git commit hash, application name, etc.

--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -1,6 +1,11 @@
 package services
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"text/template"
 
@@ -26,6 +31,8 @@ func TestValidIconURL(t *testing.T) {
 func TestGetTemplater_Slack(t *testing.T) {
 	n := Notification{
 		Slack: &SlackNotification{
+			Username:        "{{.bar}}-{{.foo}}",
+			Icon:            ":{{.foo}}:",
 			Attachments:     "{{.foo}}",
 			Blocks:          "{{.bar}}",
 			GroupingKey:     "{{.foo}}-{{.bar}}",
@@ -48,6 +55,8 @@ func TestGetTemplater_Slack(t *testing.T) {
 		return
 	}
 
+	assert.Equal(t, "world-hello", notification.Slack.Username)
+	assert.Equal(t, ":hello:", notification.Slack.Icon)
 	assert.Equal(t, "hello", notification.Slack.Attachments)
 	assert.Equal(t, "world", notification.Slack.Blocks)
 	assert.Equal(t, "hello-world", notification.Slack.GroupingKey)
@@ -62,4 +71,251 @@ func TestBuildMessageOptionsWithNonExistTemplate(t *testing.T) {
 	assert.Len(t, opts, 1)
 	assert.Empty(t, sn.GroupingKey)
 	assert.Equal(t, slackutil.Post, sn.DeliveryPolicy)
+}
+
+type chatResponseFull struct {
+	Channel          string `json:"channel"`
+	Timestamp        string `json:"ts"`         // Regular message timestamp
+	MessageTimeStamp string `json:"message_ts"` // Ephemeral message timestamp
+	Text             string `json:"text"`
+}
+
+func TestSlack_SendNotification(t *testing.T) {
+	dummyResponse, err := json.Marshal(chatResponseFull{
+		Channel:          "test",
+		Timestamp:        "1503435956.000247",
+		MessageTimeStamp: "1503435956.000247",
+		Text:             "text",
+	})
+	assert.NoError(t, err)
+
+	t.Run("only message", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			data, err := io.ReadAll(request.Body)
+			assert.NoError(t, err)
+			v := url.Values{}
+			v.Add("channel", "test-channel")
+			v.Add("text", "Annotation description")
+			v.Add("token", "something-token")
+			assert.Equal(t, string(data), v.Encode())
+
+			writer.WriteHeader(http.StatusOK)
+			_, err = writer.Write(dummyResponse)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		service := NewSlackService(SlackOptions{
+			ApiURL:             server.URL + "/",
+			Token:              "something-token",
+			InsecureSkipVerify: true,
+		})
+
+		err := service.Send(
+			Notification{Message: "Annotation description"},
+			Destination{Recipient: "test-channel", Service: "slack"},
+		)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+
+	t.Run("attachments", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			data, err := io.ReadAll(request.Body)
+			assert.NoError(t, err)
+			v := url.Values{}
+			v.Add("attachments", `[{"pretext":"pre-hello","text":"text-world","blocks":null}]`)
+			v.Add("channel", "test")
+			v.Add("text", "Attachments description")
+			v.Add("token", "something-token")
+			assert.Equal(t, string(data), v.Encode())
+
+			writer.WriteHeader(http.StatusOK)
+			_, err = writer.Write(dummyResponse)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		service := NewSlackService(SlackOptions{
+			ApiURL:             server.URL + "/",
+			Token:              "something-token",
+			InsecureSkipVerify: true,
+		})
+
+		err := service.Send(
+			Notification{
+				Message: "Attachments description",
+				Slack: &SlackNotification{
+					Attachments: `[{"pretext": "pre-hello", "text": "text-world"}]`,
+				},
+			},
+			Destination{Recipient: "test", Service: "slack"},
+		)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+
+	t.Run("blocks", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			data, err := io.ReadAll(request.Body)
+			assert.NoError(t, err)
+			v := url.Values{}
+			v.Add("attachments", "[]")
+			v.Add("blocks", `[{"type":"section","text":{"type":"plain_text","text":"Hello world"}}]`)
+			v.Add("channel", "test")
+			v.Add("text", "Attachments description")
+			v.Add("token", "something-token")
+			assert.Equal(t, string(data), v.Encode())
+
+			writer.WriteHeader(http.StatusOK)
+			_, err = writer.Write(dummyResponse)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		service := NewSlackService(SlackOptions{
+			ApiURL:             server.URL + "/",
+			Token:              "something-token",
+			InsecureSkipVerify: true,
+		})
+
+		err := service.Send(
+			Notification{
+				Message: "Attachments description",
+				Slack: &SlackNotification{
+					Blocks: `[{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}]`,
+				},
+			},
+			Destination{Recipient: "test", Service: "slack"},
+		)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+}
+
+func TestSlack_SetUsernameAndIcon(t *testing.T) {
+	dummyResponse, err := json.Marshal(chatResponseFull{
+		Channel:          "test",
+		Timestamp:        "1503435956.000247",
+		MessageTimeStamp: "1503435956.000247",
+		Text:             "text",
+	})
+	assert.NoError(t, err)
+
+	t.Run("no set", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			data, err := io.ReadAll(request.Body)
+			assert.NoError(t, err)
+			v := url.Values{}
+			v.Add("channel", "test")
+			v.Add("text", "test")
+			v.Add("token", "something-token")
+			assert.Equal(t, string(data), v.Encode())
+
+			writer.WriteHeader(http.StatusOK)
+			_, err = writer.Write(dummyResponse)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		service := NewSlackService(SlackOptions{
+			ApiURL:             server.URL + "/",
+			Token:              "something-token",
+			InsecureSkipVerify: true,
+		})
+
+		err := service.Send(
+			Notification{
+				Message: "test",
+			},
+			Destination{Recipient: "test", Service: "slack"},
+		)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+
+	t.Run("set service config", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			data, err := io.ReadAll(request.Body)
+			assert.NoError(t, err)
+			v := url.Values{}
+			v.Add("channel", "test")
+			v.Add("icon_emoji", ":smile:")
+			v.Add("text", "test")
+			v.Add("token", "something-token")
+			v.Add("username", "foo")
+
+			assert.Equal(t, string(data), v.Encode())
+
+			writer.WriteHeader(http.StatusOK)
+			_, err = writer.Write(dummyResponse)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		service := NewSlackService(SlackOptions{
+			ApiURL:             server.URL + "/",
+			Token:              "something-token",
+			Username:           "foo",
+			Icon:               ":smile:",
+			InsecureSkipVerify: true,
+		})
+
+		err := service.Send(
+			Notification{
+				Message: "test",
+			},
+			Destination{Recipient: "test", Service: "slack"},
+		)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
+
+	t.Run("set service config and template", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			data, err := io.ReadAll(request.Body)
+			assert.NoError(t, err)
+			v := url.Values{}
+			v.Add("attachments", "[]")
+			v.Add("channel", "test")
+			v.Add("icon_emoji", ":wink:")
+			v.Add("text", "test")
+			v.Add("token", "something-token")
+			v.Add("username", "template set")
+
+			assert.Equal(t, string(data), v.Encode())
+
+			writer.WriteHeader(http.StatusOK)
+			_, err = writer.Write(dummyResponse)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		service := NewSlackService(SlackOptions{
+			ApiURL:             server.URL + "/",
+			Token:              "something-token",
+			Username:           "foo",
+			Icon:               ":smile:",
+			InsecureSkipVerify: true,
+		})
+
+		err := service.Send(
+			Notification{
+				Message: "test",
+				Slack: &SlackNotification{
+					Username: "template set",
+					Icon:     ":wink:",
+				},
+			},
+			Destination{Recipient: "test", Service: "slack"},
+		)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+	})
 }


### PR DESCRIPTION
When multiple users set triggers and templates for one slack service in monorepos, etc., there was an issue where the icon and username could not be changed. Therefore, I made it possible to set a custom username and icon in the template used for Slack notifications.

If the username and icon are already set on the service side and the username and icon are also set on the template, the template will take priority.

And there were no tests for Slack notifications, so I added them.