### PR TITLE
feat: Add support for GitHub Check Runs

### DIFF
--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -489,7 +489,7 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 			}
 		}
 
-		g.client.Checks.UpdateCheckRun(
+		_, _, err = g.client.Checks.UpdateCheckRun(
 			context.Background(),
 			u[0],
 			u[1],


### PR DESCRIPTION
Adds support to be able to update GitHub Check Runs, which are more powerful than GitHub Statuses

[Link to issue in `argoproj/argo-cd`](https://github.com/argoproj/argo-cd/issues/19256)