### PR TITLE
fix: Fix memory leak in the webhook service

### DIFF
--- a/pkg/services/webhook.go
+++ b/pkg/services/webhook.go
@@ -123,6 +123,7 @@ func (s webhookService) Send(notification Notification, dest Destination) error 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if !(resp.StatusCode >= 200 && resp.StatusCode <= 299) {
 		data, err := io.ReadAll(resp.Body)
@@ -130,7 +131,10 @@ func (s webhookService) Send(notification Notification, dest Destination) error 
 			data = []byte(fmt.Sprintf("unable to read response data: %v", err))
 		}
 		return fmt.Errorf("request to %s has failed with error code %d : %s", request, resp.StatusCode, string(data))
+	} else {
+		_, _ = io.Copy(io.Discard, resp.Body)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
After using the webhook service in our setup, we noticed a consistent increase in the memory usage of argocd-notification-controller. Upon closer inspection, I found that the response body is not being closed after the server returns, preventing the client from returning the connection back to the pool.

The current implementation keeps creating new connections never releasing nor closing them.