### PR TITLE
Add support for repository dispatch notifications to GitHub service.

### DIFF
--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -743,7 +743,6 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 				ClientPayload: &payload,
 			},
 		)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Part of #356

Repository dispatch allows for triggering GitHub Actions via event type (as opposed to "workflow dispatch", which requires specifying a specific workflow to trigger). The triggering calls can pass arbitrary data via "client_payload" JSON.

API docs here: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event