### PR TITLE
fix: add parallel notification delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ data:
 
   service.slack: |
     token: $slack-token
+  
+  # Optional: Maximum concurrent notification deliveries (default: 10)
+  # Controls parallel processing of notifications to multiple destinations.
+  # Higher values speed up delivery when destinations are slow/timing out but increase resource usage.
+  # Recommended: 10-25 (small/medium clusters), 50-100 (large clusters)
+  # Note: Some services have rate limits; start low and increase if needed.
+  maxConcurrentNotifications: "25"
 ---
 apiVersion: v1
 kind: Secret
@@ -76,6 +83,7 @@ notifications.argoproj.io/subscriptions: |
       - service: slack
         recipients: [my-channel-21, my-channel-22]
 ```
+
 ## Getting Started
 
 Ready to add notifications to your project? Check out sample notifications for [cert-manager](./examples/certmanager/README.md)

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -62,6 +62,80 @@ func TestParseConfig_DefaultServiceTriggers(t *testing.T) {
 	}, cfg.ServiceDefaultTriggers)
 }
 
+func TestParseConfig_MaxConcurrentNotifications(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]string
+		expected int
+	}{
+		{
+			name: "valid positive value",
+			data: map[string]string{
+				"maxConcurrentNotifications": "25",
+			},
+			expected: 25,
+		},
+		{
+			name: "valid value 100",
+			data: map[string]string{
+				"maxConcurrentNotifications": "100",
+			},
+			expected: 100,
+		},
+		{
+			name:     "not set uses default",
+			data:     map[string]string{},
+			expected: DefaultMaxConcurrentNotifications,
+		},
+		{
+			name: "zero uses default",
+			data: map[string]string{
+				"maxConcurrentNotifications": "0",
+			},
+			expected: DefaultMaxConcurrentNotifications,
+		},
+		{
+			name: "negative uses default",
+			data: map[string]string{
+				"maxConcurrentNotifications": "-10",
+			},
+			expected: DefaultMaxConcurrentNotifications,
+		},
+		{
+			name: "invalid non-numeric uses default",
+			data: map[string]string{
+				"maxConcurrentNotifications": "invalid",
+			},
+			expected: DefaultMaxConcurrentNotifications,
+		},
+		{
+			name: "empty string uses default",
+			data: map[string]string{
+				"maxConcurrentNotifications": "",
+			},
+			expected: DefaultMaxConcurrentNotifications,
+		},
+		{
+			name: "very high value is accepted with warning",
+			data: map[string]string{
+				"maxConcurrentNotifications": "1500",
+			},
+			expected: 1500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ParseConfig(&corev1.ConfigMap{Data: tt.data}, emptySecret)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tt.expected, cfg.MaxConcurrentNotifications,
+				"MaxConcurrentNotifications should match expected value")
+		})
+	}
+}
+
 func TestReplaceStringSecret_KeyPresent(t *testing.T) {
 	val := replaceStringSecret("hello $secret-value", map[string][]byte{
 		"secret-value": []byte("world"),


### PR DESCRIPTION
Hello,

I have been encountering issues similar to what is described in #146. In my case one of the webservice in destination of the notification was not responding and was waiting for the timeout. With 3 retries this delayed significantely the time where other notification would be sent (which trigger argo workflow on our end)

This PR addresses this issue by allowing parallel notification.
For now I used a default of 50 parallel which might be high.

If we want to be on the safe side we could imagine keeping the default to 1 and allowing only the configuration.

The implementation should be backward compatible (except for the potential resource usage of the go routines hence my proposal above).

Existing configurations should work without changes, and the new `maxConcurrentNotifications` setting is optional for users who need custom tuning.