### PR TITLE
feat(slack): add template functions for user/channel/group mentions

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -264,7 +264,7 @@ This will render as: `<!subteam^SAZ94GDB8>, critical issue detected in my-app!`
 ```yaml
 template.deployment-notification: |
   message: |
-    Hey {{slackUserByEmail .author.email}}, your deployment to {{slackChannel "production"}} is complete.
+    Hey {{slackUserByEmail (call .repo.GetCommitMetadata .app.status.sync.revision).Author}}, your deployment to {{slackChannel "production"}} is complete.
     {{slackUserGroup "platform-team"}} has been notified.
 ```
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -209,7 +209,9 @@ The message is sent according to the `deliveryPolicy` string field under the `sl
 
 ## Mentioning Users, Channels, and User Groups
 
-The Slack notification service supports mentioning users by email, channels by name, and user groups by handle using special template functions. These functions automatically look up the corresponding Slack IDs and format them as proper mentions.
+The Slack notification service supports mentioning users by email, channels by name, and user groups by handle using special template functions. These functions look up the corresponding Slack IDs via the Slack API when the template is rendered and format them as proper mentions.
+
+If a lookup fails (for example, the user, channel, or group does not exist, or the required scope is missing), the function logs a warning and returns an empty string, so the rest of the message is still delivered.
 
 ### Template Functions
 
@@ -239,6 +241,9 @@ template.app-deployed: |
     {{slackUserByEmail (call .repo.GetCommitMetadata .app.status.sync.revision).Author}}, your changes have been deployed to {{.app.metadata.name}}.
 ```
 
+!!! note
+    The `.repo.GetCommitMetadata` function and `.app.status.sync.revision` field are provided by Argo CD and are only available when the notification is triggered from Argo CD. For **multi-source** applications `.app.status.sync.revision` is empty; the revisions are stored as a list in `.app.status.sync.revisions`, so select the relevant one with `index`, e.g. `(call .repo.GetCommitMetadata (index .app.status.sync.revisions 0)).Author`. The email returned by `.Author` must match the email on the user's Slack profile for `slackUserByEmail` to resolve it.
+
 #### Mentioning a channel
 
 ```yaml
@@ -248,6 +253,8 @@ template.app-health-degraded: |
 ```
 
 This will render as: `Application my-app health is degraded. Check <#C123ABC456> for more details.`
+
+A channel name may be given with or without a leading `#` (`"alerts"` and `"#alerts"` are equivalent). Note that **private channels are only visible to the lookup if the Slack bot has been invited to them**; otherwise the lookup will fail and the mention is omitted.
 
 #### Mentioning a user group
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.23
 	github.com/prometheus/client_golang v1.21.0
 	github.com/sirupsen/logrus v1.9.4
-	github.com/slack-go/slack v0.16.0
+	github.com/slack-go/slack v0.17.3
 	github.com/spf13/cast v1.7.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
-github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -158,7 +158,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
@@ -185,7 +184,6 @@ github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4 h1:4EZlYQIiyecYJlUbV
 github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4/go.mod h1:lEO7XoHJ/xNRBCxrn4h/CEB67h0kW1B0t4ooP2yrjUA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gregdel/pushover v1.3.1 h1:4bMLITOZ15+Zpi6qqoGqOPuVHCwSUvMCgVnN5Xhilfo=
@@ -306,8 +304,8 @@ github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+D
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/slack-go/slack v0.16.0 h1:khp/WCFv+Hb/B/AJaAwvcxKun0hM6grN0bUZ8xG60P8=
-github.com/slack-go/slack v0.16.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
+github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/sony/sonyflake v1.0.0 h1:MpU6Ro7tfXwgn2l5eluf9xQvQJDROTBImNCfRXn/YeM=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	texttemplate "text/template"
 
 	"github.com/argoproj/notifications-engine/pkg/services"
 	"github.com/argoproj/notifications-engine/pkg/templates"
@@ -63,7 +64,14 @@ func (n *api) Send(obj map[string]any, templates []string, dest services.Destina
 	}
 	in[serviceTypeVarName] = dest.Service
 	in[recipientVarName] = dest.Recipient
-	notification, err := n.templatesService.FormatNotification(in, templates...)
+
+	// Inject service-specific template functions (e.g. Slack mention lookups)
+	// so they are scoped to this service rather than registered globally.
+	var extraFuncs texttemplate.FuncMap
+	if p, ok := notificationService.(services.TemplateFuncsProvider); ok {
+		extraFuncs = p.TemplateFuncs()
+	}
+	notification, err := n.templatesService.FormatNotification(in, extraFuncs, templates...)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -326,3 +326,11 @@ type Templater func(notification *Notification, vars map[string]any) error
 type TemplaterSource interface {
 	GetTemplater(name string, f texttemplate.FuncMap) (Templater, error)
 }
+
+// TemplateFuncsProvider can be implemented by a NotificationService to expose
+// service-specific template functions (e.g. slackUserByEmail). The returned
+// funcs are merged into the template FuncMap for each send, keeping them
+// scoped to the specific service rather than registered globally.
+type TemplateFuncsProvider interface {
+	TemplateFuncs() texttemplate.FuncMap
+}

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 	texttemplate "text/template"
 
-	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
-	slackutil "github.com/argoproj/notifications-engine/pkg/util/slack"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 	"golang.org/x/time/rate"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
+	slackutil "github.com/argoproj/notifications-engine/pkg/util/slack"
 )
 
 // No rate limit unless Slack requests it (allows for Slack to control bursting)
@@ -38,9 +38,9 @@ var globalLookupCache = &slackLookupCache{
 
 // Regex patterns to match special markers in messages
 var (
-	slackUserEmailPattern  = regexp.MustCompile(`__SLACK_USER_EMAIL__(.+?)__`)
-	slackChannelPattern    = regexp.MustCompile(`__SLACK_CHANNEL__(.+?)__`)
-	slackUserGroupPattern  = regexp.MustCompile(`__SLACK_USERGROUP__(.+?)__`)
+	slackUserEmailPattern = regexp.MustCompile(`__SLACK_USER_EMAIL__(.+?)__`)
+	slackChannelPattern   = regexp.MustCompile(`__SLACK_CHANNEL__(.+?)__`)
+	slackUserGroupPattern = regexp.MustCompile(`__SLACK_USERGROUP__(.+?)__`)
 )
 
 type SlackNotification struct {

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
+	"sync"
 	texttemplate "text/template"
 
 	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
@@ -19,6 +21,27 @@ import (
 
 // No rate limit unless Slack requests it (allows for Slack to control bursting)
 var slackState = slackutil.NewState(rate.NewLimiter(rate.Inf, 1))
+
+// Cache for Slack API lookups to avoid repeated calls
+type slackLookupCache struct {
+	sync.RWMutex
+	usersByEmail map[string]string
+	channels     map[string]string
+	userGroups   map[string]string
+}
+
+var globalLookupCache = &slackLookupCache{
+	usersByEmail: make(map[string]string),
+	channels:     make(map[string]string),
+	userGroups:   make(map[string]string),
+}
+
+// Regex patterns to match special markers in messages
+var (
+	slackUserEmailPattern  = regexp.MustCompile(`__SLACK_USER_EMAIL__([^_]+)__`)
+	slackChannelPattern    = regexp.MustCompile(`__SLACK_CHANNEL__([^_]+)__`)
+	slackUserGroupPattern  = regexp.MustCompile(`__SLACK_USERGROUP__([^_]+)__`)
+)
 
 type SlackNotification struct {
 	Username        string                   `json:"username,omitempty"`
@@ -170,14 +193,29 @@ func buildMessageOptions(notification Notification, opts SlackOptions) (*SlackNo
 }
 
 func (s *slackService) Send(notification Notification, dest Destination) error {
-	slackNotification, msgOptions, err := buildMessageOptions(notification, s.opts)
-	if err != nil {
-		return err
-	}
 	client, err := newSlackClient(s.opts)
 	if err != nil {
 		return err
 	}
+
+	// Process Slack mentions in the message
+	notification.Message = processSlackMentions(client, notification.Message)
+
+	// Also process mentions in attachments and blocks if present
+	if notification.Slack != nil {
+		if notification.Slack.Attachments != "" {
+			notification.Slack.Attachments = processSlackMentions(client, notification.Slack.Attachments)
+		}
+		if notification.Slack.Blocks != "" {
+			notification.Slack.Blocks = processSlackMentions(client, notification.Slack.Blocks)
+		}
+	}
+
+	slackNotification, msgOptions, err := buildMessageOptions(notification, s.opts)
+	if err != nil {
+		return err
+	}
+
 	return slackutil.NewThreadedClient(
 		client,
 		slackState,
@@ -221,4 +259,154 @@ func isValidIconURL(iconURL string) bool {
 	}
 
 	return true
+}
+
+// lookupUserByEmail retrieves a Slack user ID by email address
+func lookupUserByEmail(client *slack.Client, email string) (string, error) {
+	// Check cache first
+	globalLookupCache.RLock()
+	if userID, ok := globalLookupCache.usersByEmail[email]; ok {
+		globalLookupCache.RUnlock()
+		return userID, nil
+	}
+	globalLookupCache.RUnlock()
+
+	// Make API call
+	user, err := client.GetUserByEmail(email)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup user by email %s: %w", email, err)
+	}
+
+	// Cache the result
+	globalLookupCache.Lock()
+	globalLookupCache.usersByEmail[email] = user.ID
+	globalLookupCache.Unlock()
+
+	return user.ID, nil
+}
+
+// lookupChannelByName retrieves a Slack channel ID by channel name
+func lookupChannelByName(client *slack.Client, channelName string) (string, error) {
+	// Normalize channel name (remove # if present)
+	channelName = strings.TrimPrefix(channelName, "#")
+
+	// Check cache first
+	globalLookupCache.RLock()
+	if channelID, ok := globalLookupCache.channels[channelName]; ok {
+		globalLookupCache.RUnlock()
+		return channelID, nil
+	}
+	globalLookupCache.RUnlock()
+
+	// Make API call to get all channels
+	// Note: This might need pagination for workspaces with many channels
+	var cursor string
+	for {
+		params := &slack.GetConversationsParameters{
+			Cursor:          cursor,
+			ExcludeArchived: true,
+			Limit:           1000,
+			Types:           []string{"public_channel", "private_channel"},
+		}
+		channels, nextCursor, err := client.GetConversations(params)
+		if err != nil {
+			return "", fmt.Errorf("failed to lookup channel %s: %w", channelName, err)
+		}
+
+		for _, channel := range channels {
+			if channel.Name == channelName {
+				// Cache the result
+				globalLookupCache.Lock()
+				globalLookupCache.channels[channelName] = channel.ID
+				globalLookupCache.Unlock()
+				return channel.ID, nil
+			}
+		}
+
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	return "", fmt.Errorf("channel %s not found", channelName)
+}
+
+// lookupUserGroupByName retrieves a Slack user group ID by group name
+func lookupUserGroupByName(client *slack.Client, groupName string) (string, error) {
+	// Check cache first
+	globalLookupCache.RLock()
+	if groupID, ok := globalLookupCache.userGroups[groupName]; ok {
+		globalLookupCache.RUnlock()
+		return groupID, nil
+	}
+	globalLookupCache.RUnlock()
+
+	// Make API call
+	groups, err := client.GetUserGroups(slack.GetUserGroupsOptionIncludeDisabled(false))
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup user group %s: %w", groupName, err)
+	}
+
+	for _, group := range groups {
+		if group.Handle == groupName || group.Name == groupName {
+			// Cache the result
+			globalLookupCache.Lock()
+			globalLookupCache.userGroups[groupName] = group.ID
+			globalLookupCache.Unlock()
+			return group.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("user group %s not found", groupName)
+}
+
+// processSlackMentions processes the notification message and replaces special markers with actual Slack mentions
+func processSlackMentions(client *slack.Client, message string) string {
+	// Process user mentions by email
+	message = slackUserEmailPattern.ReplaceAllStringFunc(message, func(match string) string {
+		matches := slackUserEmailPattern.FindStringSubmatch(match)
+		if len(matches) < 2 {
+			return match
+		}
+		email := matches[1]
+		userID, err := lookupUserByEmail(client, email)
+		if err != nil {
+			log.Warnf("Failed to lookup Slack user by email %s: %v", email, err)
+			return match
+		}
+		return fmt.Sprintf("<@%s>", userID)
+	})
+
+	// Process channel mentions
+	message = slackChannelPattern.ReplaceAllStringFunc(message, func(match string) string {
+		matches := slackChannelPattern.FindStringSubmatch(match)
+		if len(matches) < 2 {
+			return match
+		}
+		channelName := matches[1]
+		channelID, err := lookupChannelByName(client, channelName)
+		if err != nil {
+			log.Warnf("Failed to lookup Slack channel %s: %v", channelName, err)
+			return match
+		}
+		return fmt.Sprintf("<#%s>", channelID)
+	})
+
+	// Process user group mentions
+	message = slackUserGroupPattern.ReplaceAllStringFunc(message, func(match string) string {
+		matches := slackUserGroupPattern.FindStringSubmatch(match)
+		if len(matches) < 2 {
+			return match
+		}
+		groupName := matches[1]
+		groupID, err := lookupUserGroupByName(client, groupName)
+		if err != nil {
+			log.Warnf("Failed to lookup Slack user group %s: %v", groupName, err)
+			return match
+		}
+		return fmt.Sprintf("<!subteam^%s>", groupID)
+	})
+
+	return message
 }

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -38,9 +38,9 @@ var globalLookupCache = &slackLookupCache{
 
 // Regex patterns to match special markers in messages
 var (
-	slackUserEmailPattern  = regexp.MustCompile(`__SLACK_USER_EMAIL__([^_]+)__`)
-	slackChannelPattern    = regexp.MustCompile(`__SLACK_CHANNEL__([^_]+)__`)
-	slackUserGroupPattern  = regexp.MustCompile(`__SLACK_USERGROUP__([^_]+)__`)
+	slackUserEmailPattern  = regexp.MustCompile(`__SLACK_USER_EMAIL__(.+?)__`)
+	slackChannelPattern    = regexp.MustCompile(`__SLACK_CHANNEL__(.+?)__`)
+	slackUserGroupPattern  = regexp.MustCompile(`__SLACK_USERGROUP__(.+?)__`)
 )
 
 type SlackNotification struct {
@@ -299,7 +299,7 @@ func lookupChannelByName(client *slack.Client, channelName string) (string, erro
 	globalLookupCache.RUnlock()
 
 	// Make API call to get all channels
-	// Note: This might need pagination for workspaces with many channels
+	// Implements pagination for workspaces with many channels
 	var cursor string
 	for {
 		params := &slack.GetConversationsParameters{

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"sync"
 	texttemplate "text/template"
 
 	log "github.com/sirupsen/logrus"
@@ -21,27 +20,6 @@ import (
 
 // No rate limit unless Slack requests it (allows for Slack to control bursting)
 var slackState = slackutil.NewState(rate.NewLimiter(rate.Inf, 1))
-
-// Cache for Slack API lookups to avoid repeated calls
-type slackLookupCache struct {
-	sync.RWMutex
-	usersByEmail map[string]string
-	channels     map[string]string
-	userGroups   map[string]string
-}
-
-var globalLookupCache = &slackLookupCache{
-	usersByEmail: make(map[string]string),
-	channels:     make(map[string]string),
-	userGroups:   make(map[string]string),
-}
-
-// Regex patterns to match special markers in messages
-var (
-	slackUserEmailPattern = regexp.MustCompile(`__SLACK_USER_EMAIL__(.+?)__`)
-	slackChannelPattern   = regexp.MustCompile(`__SLACK_CHANNEL__(.+?)__`)
-	slackUserGroupPattern = regexp.MustCompile(`__SLACK_USERGROUP__(.+?)__`)
-)
 
 type SlackNotification struct {
 	Username        string                   `json:"username,omitempty"`
@@ -139,6 +117,95 @@ func NewSlackService(opts SlackOptions) NotificationService {
 	return &slackService{opts: opts}
 }
 
+// TemplateFuncs returns Slack-specific template functions (slackUserByEmail,
+// slackChannel, slackUserGroup). They are injected per-send by the API layer so
+// they are scoped to this Slack service instance rather than registered
+// globally. Each function resolves the human-readable identifier to a Slack ID
+// via the API and returns the ready-to-use mention string. On failure it logs a
+// warning and returns an empty string so the rest of the message is delivered.
+func (s *slackService) TemplateFuncs() texttemplate.FuncMap {
+	return texttemplate.FuncMap{
+		"slackUserByEmail": s.slackUserByEmail,
+		"slackChannel":     s.slackChannel,
+		"slackUserGroup":   s.slackUserGroup,
+	}
+}
+
+// slackUserByEmail looks up a Slack user by email and returns "<@USERID>".
+// Requires the users:read and users:read.email OAuth scopes.
+func (s *slackService) slackUserByEmail(email string) string {
+	client, err := newSlackClient(s.opts)
+	if err != nil {
+		log.Warnf("slackUserByEmail: failed to create client: %v", err)
+		return ""
+	}
+	user, err := client.GetUserByEmail(email)
+	if err != nil {
+		log.Warnf("slackUserByEmail: failed to lookup user %q: %v", email, err)
+		return ""
+	}
+	return fmt.Sprintf("<@%s>", user.ID)
+}
+
+// slackChannel looks up a Slack channel by name and returns "<#CHANNELID>".
+// Requires the channels:read and groups:read OAuth scopes. Note that private
+// channels are only visible when the bot has been invited to them.
+func (s *slackService) slackChannel(channelName string) string {
+	client, err := newSlackClient(s.opts)
+	if err != nil {
+		log.Warnf("slackChannel: failed to create client: %v", err)
+		return ""
+	}
+	// Accept names with or without a leading '#'.
+	channelName = strings.TrimPrefix(channelName, "#")
+	cursor := ""
+	for {
+		channels, nextCursor, err := client.GetConversations(&slack.GetConversationsParameters{
+			Cursor:          cursor,
+			ExcludeArchived: true,
+			Limit:           1000,
+			Types:           []string{"public_channel", "private_channel"},
+		})
+		if err != nil {
+			log.Warnf("slackChannel: failed to list channels: %v", err)
+			return ""
+		}
+		for _, ch := range channels {
+			if ch.Name == channelName {
+				return fmt.Sprintf("<#%s>", ch.ID)
+			}
+		}
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+	log.Warnf("slackChannel: channel %q not found", channelName)
+	return ""
+}
+
+// slackUserGroup looks up a Slack user group by handle or name and returns
+// "<!subteam^GROUPID>". Requires the usergroups:read OAuth scope.
+func (s *slackService) slackUserGroup(handle string) string {
+	client, err := newSlackClient(s.opts)
+	if err != nil {
+		log.Warnf("slackUserGroup: failed to create client: %v", err)
+		return ""
+	}
+	groups, err := client.GetUserGroups(slack.GetUserGroupsOptionIncludeDisabled(false))
+	if err != nil {
+		log.Warnf("slackUserGroup: failed to list user groups: %v", err)
+		return ""
+	}
+	for _, g := range groups {
+		if g.Handle == handle || g.Name == handle {
+			return fmt.Sprintf("<!subteam^%s>", g.ID)
+		}
+	}
+	log.Warnf("slackUserGroup: user group %q not found", handle)
+	return ""
+}
+
 func buildMessageOptions(notification Notification, opts SlackOptions) (*SlackNotification, []slack.MsgOption, error) {
 	msgOptions := []slack.MsgOption{slack.MsgOptionText(notification.Message, false)}
 	slackNotification := &SlackNotification{}
@@ -198,19 +265,6 @@ func (s *slackService) Send(notification Notification, dest Destination) error {
 		return err
 	}
 
-	// Process Slack mentions in the message
-	notification.Message = processSlackMentions(client, notification.Message)
-
-	// Also process mentions in attachments and blocks if present
-	if notification.Slack != nil {
-		if notification.Slack.Attachments != "" {
-			notification.Slack.Attachments = processSlackMentions(client, notification.Slack.Attachments)
-		}
-		if notification.Slack.Blocks != "" {
-			notification.Slack.Blocks = processSlackMentions(client, notification.Slack.Blocks)
-		}
-	}
-
 	slackNotification, msgOptions, err := buildMessageOptions(notification, s.opts)
 	if err != nil {
 		return err
@@ -259,194 +313,4 @@ func isValidIconURL(iconURL string) bool {
 	}
 
 	return true
-}
-
-// lookupUserByEmail retrieves a Slack user ID by email address
-func lookupUserByEmail(client *slack.Client, email string) (string, error) {
-	// Check cache first
-	globalLookupCache.RLock()
-	if userID, ok := globalLookupCache.usersByEmail[email]; ok {
-		globalLookupCache.RUnlock()
-		return userID, nil
-	}
-	globalLookupCache.RUnlock()
-
-	// Acquire write lock to prevent thundering herd
-	globalLookupCache.Lock()
-	defer globalLookupCache.Unlock()
-
-	// Double-check cache after acquiring write lock
-	// (another goroutine might have populated it while we were waiting)
-	if userID, ok := globalLookupCache.usersByEmail[email]; ok {
-		return userID, nil
-	}
-
-	// Make API call
-	user, err := client.GetUserByEmail(email)
-	if err != nil {
-		return "", fmt.Errorf("failed to lookup user by email %s: %w", email, err)
-	}
-
-	// Cache the result
-	globalLookupCache.usersByEmail[email] = user.ID
-
-	return user.ID, nil
-}
-
-// lookupChannelByName retrieves a Slack channel ID by channel name
-func lookupChannelByName(client *slack.Client, channelName string) (string, error) {
-	// Normalize channel name (remove # if present)
-	channelName = strings.TrimPrefix(channelName, "#")
-
-	// Check cache first
-	globalLookupCache.RLock()
-	if channelID, ok := globalLookupCache.channels[channelName]; ok {
-		globalLookupCache.RUnlock()
-		return channelID, nil
-	}
-	globalLookupCache.RUnlock()
-
-	// Acquire write lock to prevent thundering herd
-	globalLookupCache.Lock()
-	defer globalLookupCache.Unlock()
-
-	// Double-check cache after acquiring write lock
-	// (another goroutine might have populated it while we were waiting)
-	if channelID, ok := globalLookupCache.channels[channelName]; ok {
-		return channelID, nil
-	}
-
-	// Make API call to get all channels
-	// Implements pagination for workspaces with many channels
-	var cursor string
-	var targetChannelID string
-	for {
-		params := &slack.GetConversationsParameters{
-			Cursor:          cursor,
-			ExcludeArchived: true,
-			Limit:           1000,
-			Types:           []string{"public_channel", "private_channel"},
-		}
-		channels, nextCursor, err := client.GetConversations(params)
-		if err != nil {
-			return "", fmt.Errorf("failed to lookup channel %s: %w", channelName, err)
-		}
-
-		// Opportunistically cache all channels to improve future lookups
-		for _, channel := range channels {
-			globalLookupCache.channels[channel.Name] = channel.ID
-			if channel.Name == channelName {
-				targetChannelID = channel.ID
-			}
-		}
-
-		if nextCursor == "" {
-			break
-		}
-		cursor = nextCursor
-	}
-
-	if targetChannelID != "" {
-		return targetChannelID, nil
-	}
-
-	return "", fmt.Errorf("channel %s not found", channelName)
-}
-
-// lookupUserGroupByName retrieves a Slack user group ID by group name
-func lookupUserGroupByName(client *slack.Client, groupName string) (string, error) {
-	// Check cache first
-	globalLookupCache.RLock()
-	if groupID, ok := globalLookupCache.userGroups[groupName]; ok {
-		globalLookupCache.RUnlock()
-		return groupID, nil
-	}
-	globalLookupCache.RUnlock()
-
-	// Acquire write lock to prevent thundering herd
-	globalLookupCache.Lock()
-	defer globalLookupCache.Unlock()
-
-	// Double-check cache after acquiring write lock
-	// (another goroutine might have populated it while we were waiting)
-	if groupID, ok := globalLookupCache.userGroups[groupName]; ok {
-		return groupID, nil
-	}
-
-	// Make API call
-	groups, err := client.GetUserGroups(slack.GetUserGroupsOptionIncludeDisabled(false))
-	if err != nil {
-		return "", fmt.Errorf("failed to lookup user group %s: %w", groupName, err)
-	}
-
-	// Opportunistically cache all user groups to improve future lookups
-	var targetGroupID string
-	for _, group := range groups {
-		// Cache by both handle and name for flexible lookup
-		if group.Handle != "" {
-			globalLookupCache.userGroups[group.Handle] = group.ID
-		}
-		if group.Name != "" {
-			globalLookupCache.userGroups[group.Name] = group.ID
-		}
-		if group.Handle == groupName || group.Name == groupName {
-			targetGroupID = group.ID
-		}
-	}
-
-	if targetGroupID != "" {
-		return targetGroupID, nil
-	}
-
-	return "", fmt.Errorf("user group %s not found", groupName)
-}
-
-// processSlackMentions processes the notification message and replaces special markers with actual Slack mentions
-func processSlackMentions(client *slack.Client, message string) string {
-	// Process user mentions by email
-	message = slackUserEmailPattern.ReplaceAllStringFunc(message, func(match string) string {
-		matches := slackUserEmailPattern.FindStringSubmatch(match)
-		if len(matches) < 2 {
-			return match
-		}
-		email := matches[1]
-		userID, err := lookupUserByEmail(client, email)
-		if err != nil {
-			log.Warnf("Failed to lookup Slack user by email %s: %v", email, err)
-			return match
-		}
-		return fmt.Sprintf("<@%s>", userID)
-	})
-
-	// Process channel mentions
-	message = slackChannelPattern.ReplaceAllStringFunc(message, func(match string) string {
-		matches := slackChannelPattern.FindStringSubmatch(match)
-		if len(matches) < 2 {
-			return match
-		}
-		channelName := matches[1]
-		channelID, err := lookupChannelByName(client, channelName)
-		if err != nil {
-			log.Warnf("Failed to lookup Slack channel %s: %v", channelName, err)
-			return match
-		}
-		return fmt.Sprintf("<#%s>", channelID)
-	})
-
-	// Process user group mentions
-	message = slackUserGroupPattern.ReplaceAllStringFunc(message, func(match string) string {
-		matches := slackUserGroupPattern.FindStringSubmatch(match)
-		if len(matches) < 2 {
-			return match
-		}
-		groupName := matches[1]
-		groupID, err := lookupUserGroupByName(client, groupName)
-		if err != nil {
-			log.Warnf("Failed to lookup Slack user group %s: %v", groupName, err)
-			return match
-		}
-		return fmt.Sprintf("<!subteam^%s>", groupID)
-	})
-
-	return message
 }

--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"text/template"
 
-	slackutil "github.com/argoproj/notifications-engine/pkg/util/slack"
 	"github.com/slack-go/slack"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	slackutil "github.com/argoproj/notifications-engine/pkg/util/slack"
 )
 
 func TestValidIconEmoji(t *testing.T) {
@@ -672,7 +672,7 @@ func TestProcessSlackMentions(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"ok":   true,
 				"user": response,
 			})
@@ -699,7 +699,7 @@ func TestProcessSlackMentions(t *testing.T) {
 			}
 			response.ResponseMetadata.NextCursor = ""
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(response)
+			_ = json.NewEncoder(w).Encode(response)
 		case strings.Contains(r.URL.Path, "usergroups.list"):
 			// Mock GetUserGroups response
 			response := struct {
@@ -716,7 +716,7 @@ func TestProcessSlackMentions(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(response)
+			_ = json.NewEncoder(w).Encode(response)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -785,7 +785,7 @@ func TestLookupCaching(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"ok":   true,
 				"user": response,
 			})
@@ -833,7 +833,7 @@ func TestSlackSendWithMentions(t *testing.T) {
 				},
 			}
 			writer.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(writer).Encode(map[string]interface{}{
+			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
 				"ok":   true,
 				"user": response,
 			})

--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -580,104 +580,18 @@ func TestSlack_SendNotification_WithInvalidJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to unmarshal")
 }
 
-func TestSlackUserEmailPattern(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{
-			name:     "valid user email marker",
-			input:    "__SLACK_USER_EMAIL__user@example.com__",
-			expected: true,
-		},
-		{
-			name:     "invalid marker",
-			input:    "user@example.com",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matches := slackUserEmailPattern.MatchString(tt.input)
-			assert.Equal(t, tt.expected, matches)
-		})
-	}
-}
-
-func TestSlackChannelPattern(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{
-			name:     "valid channel marker",
-			input:    "__SLACK_CHANNEL__general__",
-			expected: true,
-		},
-		{
-			name:     "invalid marker",
-			input:    "general",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matches := slackChannelPattern.MatchString(tt.input)
-			assert.Equal(t, tt.expected, matches)
-		})
-	}
-}
-
-func TestSlackUserGroupPattern(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{
-			name:     "valid usergroup marker",
-			input:    "__SLACK_USERGROUP__developers__",
-			expected: true,
-		},
-		{
-			name:     "invalid marker",
-			input:    "developers",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matches := slackUserGroupPattern.MatchString(tt.input)
-			assert.Equal(t, tt.expected, matches)
-		})
-	}
-}
-
-func TestProcessSlackMentions(t *testing.T) {
-	// Mock server to handle Slack API calls
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// mentionMockServer returns an httptest server that answers the Slack lookup
+// endpoints used by the template functions.
+func mentionMockServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case strings.Contains(r.URL.Path, "users.lookupByEmail"):
-			// Mock GetUserByEmail response
-			response := slack.User{
-				ID:   "U024BE7LH",
-				Name: "testuser",
-				Profile: slack.UserProfile{
-					Email: "user@example.com",
-				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"ok":   true,
-				"user": response,
+				"user": slack.User{ID: "U024BE7LH", Name: "testuser"},
 			})
 		case strings.Contains(r.URL.Path, "conversations.list"):
-			// Mock GetConversations response
 			response := struct {
 				OK               bool            `json:"ok"`
 				Channels         []slack.Channel `json:"channels"`
@@ -687,191 +601,95 @@ func TestProcessSlackMentions(t *testing.T) {
 			}{
 				OK: true,
 				Channels: []slack.Channel{
-					{
-						GroupConversation: slack.GroupConversation{
-							Conversation: slack.Conversation{
-								ID: "C123ABC456",
-							},
-							Name: "general",
-						},
-					},
+					{GroupConversation: slack.GroupConversation{
+						Conversation: slack.Conversation{ID: "C123ABC456"},
+						Name:         "general",
+					}},
 				},
 			}
-			response.ResponseMetadata.NextCursor = ""
-			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(response)
 		case strings.Contains(r.URL.Path, "usergroups.list"):
-			// Mock GetUserGroups response
-			response := struct {
+			_ = json.NewEncoder(w).Encode(struct {
 				OK         bool              `json:"ok"`
 				UserGroups []slack.UserGroup `json:"usergroups"`
 			}{
 				OK: true,
 				UserGroups: []slack.UserGroup{
-					{
-						ID:     "SAZ94GDB8",
-						Handle: "developers",
-						Name:   "Developers",
-					},
+					{ID: "SAZ94GDB8", Handle: "developers", Name: "Developers"},
 				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(response)
+			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
-
-	client := slack.New("test-token", slack.OptionAPIURL(server.URL+"/"))
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "user mention by email",
-			input:    "Hey __SLACK_USER_EMAIL__user@example.com__, thanks!",
-			expected: "Hey <@U024BE7LH>, thanks!",
-		},
-		{
-			name:     "channel mention",
-			input:    "Check __SLACK_CHANNEL__general__ for updates",
-			expected: "Check <#C123ABC456> for updates",
-		},
-		{
-			name:     "user group mention",
-			input:    "Hey __SLACK_USERGROUP__developers__, new task!",
-			expected: "Hey <!subteam^SAZ94GDB8>, new task!",
-		},
-		{
-			name:     "multiple mentions",
-			input:    "Hey __SLACK_USER_EMAIL__user@example.com__, check __SLACK_CHANNEL__general__",
-			expected: "Hey <@U024BE7LH>, check <#C123ABC456>",
-		},
-		{
-			name:     "no mentions",
-			input:    "Just a regular message",
-			expected: "Just a regular message",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Clear cache before each test
-			globalLookupCache.Lock()
-			globalLookupCache.usersByEmail = make(map[string]string)
-			globalLookupCache.channels = make(map[string]string)
-			globalLookupCache.userGroups = make(map[string]string)
-			globalLookupCache.Unlock()
-
-			result := processSlackMentions(client, tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }
 
-func TestLookupCaching(t *testing.T) {
-	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if strings.Contains(r.URL.Path, "users.lookupByEmail") {
-			response := slack.User{
-				ID:   "U024BE7LH",
-				Name: "testuser",
-				Profile: slack.UserProfile{
-					Email: "user@example.com",
-				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"ok":   true,
-				"user": response,
-			})
-		}
-	}))
-	defer server.Close()
-
-	client := slack.New("test-token", slack.OptionAPIURL(server.URL+"/"))
-
-	// Clear cache
-	globalLookupCache.Lock()
-	globalLookupCache.usersByEmail = make(map[string]string)
-	globalLookupCache.Unlock()
-
-	// First lookup should make an API call
-	userID1, err := lookupUserByEmail(client, "user@example.com")
-	assert.NoError(t, err)
-	assert.Equal(t, "U024BE7LH", userID1)
-	assert.Equal(t, 1, callCount)
-
-	// Second lookup should use cache, no additional API call
-	userID2, err := lookupUserByEmail(client, "user@example.com")
-	assert.NoError(t, err)
-	assert.Equal(t, "U024BE7LH", userID2)
-	assert.Equal(t, 1, callCount) // Call count should not increase
-}
-
-func TestSlackSendWithMentions(t *testing.T) {
-	dummyResponse, err := json.Marshal(chatResponseFull{
-		Channel:          "test",
-		Timestamp:        "1503435956.000247",
-		MessageTimeStamp: "1503435956.000247",
-		Text:             "text",
-	})
-	assert.NoError(t, err)
-
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		switch {
-		case strings.Contains(request.URL.Path, "users.lookupByEmail"):
-			response := slack.User{
-				ID:   "U024BE7LH",
-				Name: "testuser",
-				Profile: slack.UserProfile{
-					Email: "user@example.com",
-				},
-			}
-			writer.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(writer).Encode(map[string]interface{}{
-				"ok":   true,
-				"user": response,
-			})
-		case strings.Contains(request.URL.Path, "chat.postMessage"):
-			data, err := io.ReadAll(request.Body)
-			assert.NoError(t, err)
-
-			// Verify that the message contains the processed mention
-			// URL decode the body first since it's form-encoded
-			bodyStr, err := url.QueryUnescape(string(data))
-			assert.NoError(t, err)
-			assert.Contains(t, bodyStr, "<@U024BE7LH>")
-
-			writer.WriteHeader(http.StatusOK)
-			_, err = writer.Write(dummyResponse)
-			assert.NoError(t, err)
-		default:
-			writer.WriteHeader(http.StatusOK)
-			_, err = writer.Write(dummyResponse)
-			assert.NoError(t, err)
-		}
-	}))
-	defer server.Close()
-
-	// Clear cache
-	globalLookupCache.Lock()
-	globalLookupCache.usersByEmail = make(map[string]string)
-	globalLookupCache.Unlock()
-
-	service := NewSlackService(SlackOptions{
-		ApiURL:             server.URL + "/",
-		Token:              "something-token",
+func newMentionService(t *testing.T, apiURL string) *slackService {
+	t.Helper()
+	svc, ok := NewSlackService(SlackOptions{
+		Token:              "test-token",
+		ApiURL:             apiURL + "/",
 		InsecureSkipVerify: true,
+	}).(*slackService)
+	require.True(t, ok)
+	return svc
+}
+
+func TestSlackTemplateFuncs(t *testing.T) {
+	server := mentionMockServer()
+	defer server.Close()
+
+	fns := newMentionService(t, server.URL).TemplateFuncs()
+
+	t.Run("slackUserByEmail resolves to mention", func(t *testing.T) {
+		byEmail := fns["slackUserByEmail"].(func(string) string)
+		assert.Equal(t, "<@U024BE7LH>", byEmail("user@example.com"))
 	})
 
-	err = service.Send(
-		Notification{Message: "Hey __SLACK_USER_EMAIL__user@example.com__, thanks for your commit!"},
-		Destination{Recipient: "test-channel", Service: "slack"},
-	)
-	assert.NoError(t, err)
+	t.Run("slackChannel resolves to link", func(t *testing.T) {
+		channel := fns["slackChannel"].(func(string) string)
+		assert.Equal(t, "<#C123ABC456>", channel("general"))
+	})
+
+	t.Run("slackChannel accepts a leading '#'", func(t *testing.T) {
+		channel := fns["slackChannel"].(func(string) string)
+		assert.Equal(t, "<#C123ABC456>", channel("#general"))
+	})
+
+	t.Run("slackUserGroup resolves by handle", func(t *testing.T) {
+		group := fns["slackUserGroup"].(func(string) string)
+		assert.Equal(t, "<!subteam^SAZ94GDB8>", group("developers"))
+	})
+
+	t.Run("slackUserGroup resolves by name", func(t *testing.T) {
+		group := fns["slackUserGroup"].(func(string) string)
+		assert.Equal(t, "<!subteam^SAZ94GDB8>", group("Developers"))
+	})
+}
+
+func TestSlackTemplateFuncs_NotFound(t *testing.T) {
+	server := mentionMockServer()
+	defer server.Close()
+
+	fns := newMentionService(t, server.URL).TemplateFuncs()
+
+	// Failed lookups log a warning and return an empty string so the rest of
+	// the message is still delivered.
+	assert.Equal(t, "", fns["slackChannel"].(func(string) string)("missing"))
+	assert.Equal(t, "", fns["slackUserGroup"].(func(string) string)("missing"))
+}
+
+func TestSlackTemplateFuncs_InTemplate(t *testing.T) {
+	server := mentionMockServer()
+	defer server.Close()
+
+	svc := newMentionService(t, server.URL)
+
+	n := SlackNotification{Username: `{{slackUserByEmail "user@example.com"}}`}
+	templater, err := n.GetTemplater("test", svc.TemplateFuncs())
+	require.NoError(t, err)
+
+	var result Notification
+	require.NoError(t, templater(&result, map[string]any{}))
+	assert.Equal(t, "<@U024BE7LH>", result.Slack.Username)
 }

--- a/pkg/templates/service.go
+++ b/pkg/templates/service.go
@@ -21,6 +21,17 @@ func NewService(templates map[string]services.Notification) (*service, error) {
 	delete(f, "env")
 	delete(f, "expandenv")
 
+	// Add Slack-specific template functions
+	f["slackUserByEmail"] = func(email string) string {
+		return fmt.Sprintf("__SLACK_USER_EMAIL__%s__", email)
+	}
+	f["slackChannel"] = func(channelName string) string {
+		return fmt.Sprintf("__SLACK_CHANNEL__%s__", channelName)
+	}
+	f["slackUserGroup"] = func(groupName string) string {
+		return fmt.Sprintf("__SLACK_USERGROUP__%s__", groupName)
+	}
+
 	svc := &service{templaters: map[string]services.Templater{}}
 	for name, cfg := range templates {
 		templater, err := cfg.GetTemplater(name, f)

--- a/pkg/templates/service.go
+++ b/pkg/templates/service.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	texttemplate "text/template"
 
 	"github.com/Masterminds/sprig/v3"
 
@@ -9,11 +10,12 @@ import (
 )
 
 type Service interface {
-	FormatNotification(vars map[string]any, templates ...string) (*services.Notification, error)
+	FormatNotification(vars map[string]any, extraFuncs texttemplate.FuncMap, templates ...string) (*services.Notification, error)
 }
 
 type service struct {
-	templaters map[string]services.Templater
+	templates map[string]services.Notification
+	baseFuncs texttemplate.FuncMap
 }
 
 func NewService(templates map[string]services.Notification) (*service, error) {
@@ -21,36 +23,33 @@ func NewService(templates map[string]services.Notification) (*service, error) {
 	delete(f, "env")
 	delete(f, "expandenv")
 
-	// Add Slack-specific template functions
-	f["slackUserByEmail"] = func(email string) string {
-		return fmt.Sprintf("__SLACK_USER_EMAIL__%s__", email)
-	}
-	f["slackChannel"] = func(channelName string) string {
-		return fmt.Sprintf("__SLACK_CHANNEL__%s__", channelName)
-	}
-	f["slackUserGroup"] = func(groupName string) string {
-		return fmt.Sprintf("__SLACK_USERGROUP__%s__", groupName)
-	}
-
-	svc := &service{templaters: map[string]services.Templater{}}
-	for name, cfg := range templates {
-		templater, err := cfg.GetTemplater(name, f)
-		if err != nil {
-			return nil, err
-		}
-		svc.templaters[name] = templater
-	}
-	return svc, nil
+	return &service{templates: templates, baseFuncs: f}, nil
 }
 
-func (s *service) FormatNotification(vars map[string]any, templates ...string) (*services.Notification, error) {
+func (s *service) FormatNotification(vars map[string]any, extraFuncs texttemplate.FuncMap, templates ...string) (*services.Notification, error) {
+	f := s.baseFuncs
+	if len(extraFuncs) > 0 {
+		merged := make(texttemplate.FuncMap, len(s.baseFuncs)+len(extraFuncs))
+		for k, v := range s.baseFuncs {
+			merged[k] = v
+		}
+		for k, v := range extraFuncs {
+			merged[k] = v
+		}
+		f = merged
+	}
+
 	var notification services.Notification
 	for _, templateName := range templates {
-		templater, ok := s.templaters[templateName]
+		cfg, ok := s.templates[templateName]
 		if !ok {
 			return nil, fmt.Errorf("template '%s' is not supported", templateName)
 		}
 
+		templater, err := cfg.GetTemplater(templateName, f)
+		if err != nil {
+			return nil, err
+		}
 		if err := templater(&notification, vars); err != nil {
 			return nil, err
 		}

--- a/pkg/templates/service_test.go
+++ b/pkg/templates/service_test.go
@@ -20,7 +20,7 @@ func TestFormat_Message(t *testing.T) {
 
 	notification, err := svc.FormatNotification(map[string]any{
 		"foo": "hello",
-	}, "test")
+	}, nil, "test")
 
 	require.NoError(t, err)
 
@@ -36,7 +36,7 @@ func TestNewService_Success(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, svc)
-		assert.Len(t, svc.templaters, 1)
+		assert.Len(t, svc.templates, 1)
 	})
 
 	t.Run("Multiple templates", func(t *testing.T) {
@@ -53,14 +53,14 @@ func TestNewService_Success(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, svc)
-		assert.Len(t, svc.templaters, 3)
+		assert.Len(t, svc.templates, 3)
 	})
 
 	t.Run("Empty templates map", func(t *testing.T) {
 		svc, err := NewService(map[string]services.Notification{})
 		require.NoError(t, err)
 		require.NotNil(t, svc)
-		assert.Empty(t, svc.templaters)
+		assert.Empty(t, svc.templates)
 	})
 
 	t.Run("Env and expandenv functions are removed", func(t *testing.T) {
@@ -75,13 +75,18 @@ func TestNewService_Success(t *testing.T) {
 	})
 }
 
-func TestNewService_InvalidTemplate(t *testing.T) {
+func TestFormatNotification_InvalidTemplate(t *testing.T) {
 	t.Run("Invalid template syntax", func(t *testing.T) {
-		_, err := NewService(map[string]services.Notification{
+		// Parsing is deferred to FormatNotification, so NewService succeeds and
+		// the syntax error surfaces when the template is formatted.
+		svc, err := NewService(map[string]services.Notification{
 			"invalid": {
 				Message: "{{.foo",
 			},
 		})
+		require.NoError(t, err)
+
+		_, err = svc.FormatNotification(map[string]any{}, nil, "invalid")
 		require.Error(t, err)
 	})
 }
@@ -97,7 +102,7 @@ func TestFormatNotification_Success(t *testing.T) {
 
 		notification, err := svc.FormatNotification(map[string]any{
 			"name": "World",
-		}, "greeting")
+		}, nil, "greeting")
 
 		require.NoError(t, err)
 		assert.Equal(t, "Hello World!", notification.Message)
@@ -118,7 +123,7 @@ func TestFormatNotification_Success(t *testing.T) {
 		notification, err := svc.FormatNotification(map[string]any{
 			"first":  "First",
 			"second": "Second",
-		}, "template1", "template2")
+		}, nil, "template1", "template2")
 
 		require.NoError(t, err)
 		assert.Equal(t, "Second", notification.Message)
@@ -134,7 +139,7 @@ func TestFormatNotification_Success(t *testing.T) {
 
 		notification, err := svc.FormatNotification(map[string]any{
 			"name": "test",
-		}, "complex")
+		}, nil, "complex")
 
 		require.NoError(t, err)
 		assert.Equal(t, "TEST", notification.Message)
@@ -148,7 +153,7 @@ func TestFormatNotification_Success(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		notification, err := svc.FormatNotification(map[string]any{})
+		notification, err := svc.FormatNotification(map[string]any{}, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, notification)
 		assert.Empty(t, notification.Message)
@@ -163,7 +168,7 @@ func TestFormatNotification_TemplateNotFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	notification, err := svc.FormatNotification(map[string]any{}, "nonexistent")
+	notification, err := svc.FormatNotification(map[string]any{}, nil, "nonexistent")
 	require.Error(t, err)
 	assert.Nil(t, notification)
 	assert.Contains(t, err.Error(), "template 'nonexistent' is not supported")
@@ -180,7 +185,7 @@ func TestFormatNotification_TemplateExecutionError(t *testing.T) {
 	// This should trigger an error during template execution
 	notification, err := svc.FormatNotification(map[string]any{
 		"other": "value",
-	}, "test")
+	}, nil, "test")
 
 	require.Error(t, err)
 	assert.Nil(t, notification)
@@ -197,7 +202,7 @@ func TestFormatNotification_MultipleTemplatesWithError(t *testing.T) {
 	// First template is valid, second doesn't exist
 	notification, err := svc.FormatNotification(map[string]any{
 		"foo": "bar",
-	}, "valid", "invalid")
+	}, nil, "valid", "invalid")
 
 	require.Error(t, err)
 	assert.Nil(t, notification)


### PR DESCRIPTION
  Add ability to mention Slack users by email, channels by name, and user
  groups by handle instead of requiring Slack IDs. This enables notifying
  commit authors and other users without prior knowledge of their Slack IDs.

  Introduces three template functions:
  - slackUserByEmail: lookup user ID by email address
  - slackChannel: lookup channel ID by channel name
  - slackUserGroup: lookup user group ID by handle/name

  Lookups are cached in-memory to minimize API calls. Failed lookups are
  logged as warnings and preserve the original text in the message.

  Fixes #230
  Fixes #253