### PR TITLE
fix(annotations): only update notified annotation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -256,7 +256,7 @@ func (c *notificationController) processResourceWithAPI(api api.API, resource me
 		}
 	}
 
-	return notificationsState.Persist(resource)
+	return notificationsState.Persist()
 }
 
 func (c *notificationController) getDestinations(resource metav1.Object, cfg api.Config) services.Destinations {

--- a/pkg/controller/state.go
+++ b/pkg/controller/state.go
@@ -69,7 +69,7 @@ func (s NotificationsState) SetAlreadyNotified(isSelfConfig bool, apiNamespace, 
 }
 
 // Persist returns a map of annotations that need to be updated in the resource
-func (s NotificationsState) Persist(res metav1.Object) (map[string]any, error) {
+func (s NotificationsState) Persist() (map[string]any, error) {
 	s.truncate(notifiedHistoryMaxSize)
 
 	notifiedAnnotationKey := subscriptions.NotifiedAnnotationKey()

--- a/pkg/controller/state.go
+++ b/pkg/controller/state.go
@@ -68,20 +68,15 @@ func (s NotificationsState) SetAlreadyNotified(isSelfConfig bool, apiNamespace, 
 	return true
 }
 
-func (s NotificationsState) Persist(res metav1.Object) (map[string]string, error) {
+// Persist returns a map of annotations that need to be updated in the resource
+func (s NotificationsState) Persist(res metav1.Object) (map[string]any, error) {
 	s.truncate(notifiedHistoryMaxSize)
 
 	notifiedAnnotationKey := subscriptions.NotifiedAnnotationKey()
-	annotations := map[string]string{}
-
-	if res.GetAnnotations() != nil {
-		for k, v := range res.GetAnnotations() {
-			annotations[k] = v
-		}
-	}
+	annotations := map[string]any{}
 
 	if len(s) == 0 {
-		delete(annotations, notifiedAnnotationKey)
+		annotations[notifiedAnnotationKey] = nil
 	} else {
 		stateJson, err := json.Marshal(s)
 		if err != nil {


### PR DESCRIPTION
DRAFT

When persisting the "notified" annotation, do not overwrite any other annotations.

This avoids the case when a custom annotation is changed while processing is running, and then overwritten by the action of updating the "notified" annotation (that previously wrote all annotations).

I could not find any open issue for this. If you'd like, I can create one.

If you'd like this to be done in a different way, eg keeping annotations as map[string]string, let me know
