### PR TITLE
docs: fix typos in service docs

### DIFF
--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -53,7 +53,7 @@ metadata:
 data:
   templates:
     template.app-deployed: |
-      messsage: Application {{.app.metadata.name}} is now running new version of deployments manifests.
+      message: Application {{.app.metadata.name}} is now running new version of deployments manifests.
 ```
 
 8. Create subscription for your Grafana integration

--- a/docs/services/telegram.md
+++ b/docs/services/telegram.md
@@ -34,7 +34,7 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: -1000000000000
 ```
 
-If your private chat contains threads, you can optionally specify a thread id by seperating it with a `|`:
+If your private chat contains threads, you can optionally specify a thread id by separating it with a `|`:
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
Fixes misspellings across two docs, found using codespell.