### PR TITLE
fix(controller): skip triggers not configured in this API in namespac…

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -190,10 +190,11 @@ func (c *notificationController) isSelfServiceConfigureApi(api api.API) bool {
 }
 
 func (c *notificationController) processResourceWithAPI(api api.API, resource metav1.Object, logEntry *log.Entry, eventSequence *NotificationEventSequence) (map[string]string, error) {
-	apiNamespace := api.GetConfig().Namespace
+	cfg := api.GetConfig()
+	apiNamespace := cfg.Namespace
 	notificationsState := NewStateFromRes(resource)
 
-	destinations := c.getDestinations(resource, api.GetConfig())
+	destinations := c.getDestinations(resource, cfg)
 	if len(destinations) == 0 {
 		return resource.GetAnnotations(), nil
 	}
@@ -204,6 +205,16 @@ func (c *notificationController) processResourceWithAPI(api api.API, resource me
 	}
 
 	for trigger, destinations := range destinations {
+		// In namespace-support mode, multiple APIs are iterated per resource — each may
+		// legitimately have only a subset of triggers configured. Skip triggers that
+		// aren't configured in this API to avoid spurious "not configured" errors when
+		// a subscribed trigger lives in a different API in the same iteration.
+		if c.namespaceSupport {
+			if _, ok := cfg.Triggers[trigger]; !ok {
+				logEntry.Debugf("Skipping trigger %s: not configured in namespace %s", trigger, apiNamespace)
+				continue
+			}
+		}
 		res, err := api.RunTrigger(trigger, un.Object)
 		if err != nil {
 			logEntry.Errorf("Failed to evaluate condition of trigger %s: %v using the configuration in namespace %s", trigger, err, apiNamespace)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -151,7 +151,7 @@ func TestSendsNotificationIfTriggered(t *testing.T) {
 	require.NoError(t, err)
 
 	receivedObj := map[string]any{}
-	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
 	api.EXPECT().Send(mock.MatchedBy(func(obj map[string]any) bool {
 		receivedObj = obj
@@ -182,7 +182,7 @@ func TestDoesNotSendNotificationIfAnnotationPresent(t *testing.T) {
 	ctrl, api, err := newController(t, ctx, newFakeClient(app))
 	require.NoError(t, err)
 
-	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
 
 	_, err = ctrl.processResourceWithAPI(api, app, logEntry, &NotificationEventSequence{})
@@ -209,7 +209,7 @@ func TestDoesNotSendNotificationIfTooManyCommitStatusesReceived(t *testing.T) {
 	ctrl, api, err := newController(t, ctx, newFakeClient(app))
 	require.NoError(t, err)
 
-	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil).Times(2)
 	api.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(&services.TooManyGitHubCommitStatusesError{Sha: "sha", Context: "context"}).Times(1)
 
@@ -248,7 +248,7 @@ func TestRetriesNotificationIfSendThrows(t *testing.T) {
 	ctrl, api, err := newController(t, ctx, newFakeClient(app))
 	require.NoError(t, err)
 
-	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil).Times(2)
 	api.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("boom")).Times(2)
 
@@ -278,7 +278,7 @@ func TestRemovesAnnotationIfNoTrigger(t *testing.T) {
 	ctrl, api, err := newController(t, ctx, newFakeClient(app))
 	require.NoError(t, err)
 
-	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: false}}, nil)
 
 	annotations, err := ctrl.processResourceWithAPI(api, app, logEntry, &NotificationEventSequence{})
@@ -311,7 +311,7 @@ func TestUpdatedAnnotationsSavedAsPatch(t *testing.T) {
 	})
 	ctrl, api, err := newController(t, ctx, client)
 	require.NoError(t, err)
-	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: false}}, nil)
 
 	go ctrl.Run(1, ctx.Done())
@@ -443,7 +443,7 @@ func TestWithEventCallback(t *testing.T) {
 
 			ctrl, api, err := newController(t, ctx, newFakeClient(app), WithEventCallback(mockEventCallback))
 			ctrl.namespaceSupport = false
-			api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
+			api.EXPECT().GetConfig().Return(notificationApi.Config{Triggers: map[string][]triggers.Condition{"my-trigger": nil}}).AnyTimes()
 			require.NoError(t, err)
 			ctrl.apiFactory = &mocks.FakeFactory{Api: api, Err: tc.apiErr}
 
@@ -488,7 +488,7 @@ func TestProcessResourceWithAPIWithSelfService(t *testing.T) {
 	receivedObj := map[string]any{}
 
 	// SelfService API: config has IsSelfServiceConfig set to true
-	api.EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: namespace}).AnyTimes()
+	api.EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: namespace, Triggers: map[string][]triggers.Condition{trigger: nil}}).AnyTimes()
 	api.EXPECT().RunTrigger(trigger, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
 	api.EXPECT().Send(mock.MatchedBy(func(obj map[string]any) bool {
 		receivedObj = obj
@@ -505,6 +505,34 @@ func TestProcessResourceWithAPIWithSelfService(t *testing.T) {
 	state := NewState(annotations[notifiedAnnotationKey])
 	assert.NotZero(t, state[StateItemKey(true, namespace, trigger, triggers.ConditionResult{}, services.Destination{Service: "mock", Recipient: "recipient"})])
 	assert.Equal(t, app.Object, receivedObj)
+}
+
+// verify that, in namespace-support mode, an API that does not have the
+// resource's subscribed trigger configured is skipped without invoking
+// RunTrigger or emitting an error. Without this guard, the per-namespace
+// API path produces spurious "trigger '<name>' is not configured" errors
+// for every subscribed trigger on every reconcile.
+func TestProcessResourceWithAPIWithSelfServiceSkipsUnconfiguredTrigger(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	app := newResource("test", withAnnotations(map[string]string{
+		subscriptions.SubscribeAnnotationKey("my-trigger", "mock"): "recipient",
+	}))
+
+	ctrl, api, err := newController(t, ctx, newFakeClient(app))
+	require.NoError(t, err)
+	ctrl.namespaceSupport = true
+
+	// Config omits "my-trigger" — the controller should skip it rather than calling RunTrigger.
+	api.EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: "my-namespace"}).AnyTimes()
+	api.EXPECT().RunTrigger(gomock.Any(), gomock.Any()).Times(0)
+	api.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	eventSequence := NotificationEventSequence{}
+	_, err = ctrl.processResourceWithAPI(api, app, logEntry, &eventSequence)
+	require.NoError(t, err)
+	assert.Empty(t, eventSequence.Warnings)
+	assert.Empty(t, eventSequence.Errors)
 }
 
 // verify notification sent to both default and self-service configuration after calling processResourceWithAPI when using self-service
@@ -528,13 +556,13 @@ func TestProcessItemsWithSelfService(t *testing.T) {
 
 	ctrl.namespaceSupport = true
 	// SelfService API: config has IsSelfServiceConfig set to true
-	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: "selfservice_namespace"}).Times(3)
+	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: "selfservice_namespace", Triggers: map[string][]triggers.Condition{triggerName: nil}}).AnyTimes()
 	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().RunTrigger(triggerName, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
 	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().Send(mock.MatchedBy(func(_ map[string]any) bool {
 		return true
 	}), []string{"test"}, destination).Return(nil).AnyTimes()
 
-	apiMap["default"].(*mocks.MockAPI).EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: false, Namespace: "default"}).Times(3)
+	apiMap["default"].(*mocks.MockAPI).EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: false, Namespace: "default", Triggers: map[string][]triggers.Condition{triggerName: nil}}).AnyTimes()
 	apiMap["default"].(*mocks.MockAPI).EXPECT().RunTrigger(triggerName, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
 	apiMap["default"].(*mocks.MockAPI).EXPECT().Send(mock.MatchedBy(func(_ map[string]any) bool {
 		return true


### PR DESCRIPTION
## Summary

In namespace-support mode (`NewControllerWithNamespaceSupport`), `processResourceWithAPI` is invoked once per API returned from `apiFactory.GetAPIsFromNamespace(...)`. typically the cluster-scoped default config plus any per-namespace self-service config. 

The current code asks every API to evaluate every subscribed trigger. Each API then logs `"Failed to evaluate condition of trigger '<name>': trigger '<name>' is not configured using the configuration in namespace ..."` for every trigger that lives in *another* API in the same iteration. With many resources subscribing to many triggers, the result is high-volume spurious error logs on every reconcile.

This PR adds a guard so that, in namespace-support mode, an API only evaluates triggers it has configured. Other APIs in the same iteration will handle the triggers they own.

## Why this matters

Observed in production with [argo-rollouts](https://github.com/argoproj/argo-rollouts) using `NewControllerWithNamespaceSupport`: ~5,000–16,000 spurious error logs per hour per cluster on v1.9.0 (which bumped this library from v0.4.1 → v0.5.0 and promoted [the log line](https://github.com/argoproj/notifications-engine/blob/v0.5.0/pkg/controller/controller.go#L207) from `Debugf` to `Errorf`). The errors mask real issues and trigger noisy alerting downstream.

This is the underlying bug discussed in argoproj/argo-rollouts#3459 (zachaller, COLLABORATOR: *"the fix will probably be in notification-engine and is related to the self service namespaced notification support"*) and argoproj/argo-rollouts#4222.

## Related

- argoproj/argo-rollouts#3459
- argoproj/argo-rollouts#4222
- argoproj/argo-rollouts#3132
