### PR TITLE
fix(subscriptions): preserve recipient separators on unsubscribe

### DIFF
--- a/pkg/subscriptions/annotations.go
+++ b/pkg/subscriptions/annotations.go
@@ -159,7 +159,7 @@ func (a Annotations) Unsubscribe(trigger string, service string, recipient strin
 			if r[i] == recipient {
 				updatedRecipients := append(r[:i], r[i+1:]...)
 				if len(updatedRecipients) > 0 {
-					a[k] = strings.Join(updatedRecipients, "")
+					a[k] = strings.Join(updatedRecipients, ";")
 				} else {
 					delete(a, k)
 				}

--- a/pkg/subscriptions/annotations_test.go
+++ b/pkg/subscriptions/annotations_test.go
@@ -259,6 +259,19 @@ func TestUnsubscribe(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestUnsubscribe_PreservesRecipientSeparator(t *testing.T) {
+	a := Annotations(map[string]string{
+		"notifications.argoproj.io/subscribe.my-trigger.slack": "my-channel1;my-channel2;my-channel3",
+	})
+
+	a.Unsubscribe("my-trigger", "slack", "my-channel2")
+
+	assert.Equal(t, "my-channel1;my-channel3", a["notifications.argoproj.io/subscribe.my-trigger.slack"])
+	assert.True(t, a.Has("slack", "my-channel1"))
+	assert.True(t, a.Has("slack", "my-channel3"))
+	assert.False(t, a.Has("slack", "my-channel1my-channel3"))
+}
+
 func TestSetAnnotationPrefix(t *testing.T) {
 	origPrefix := annotationPrefix
 	defer func() {


### PR DESCRIPTION
Small bug in `Annotations.Unsubscribe()`.

If an annotation has a few recipients, unsubscribing one of them rebuilds the value with no `;`. So `my-channel1;my-channel2;my-channel3` turns into `my-channel1my-channel3`. Kinda busted, and the remaining subscription stops matching real recipients.

This patch keeps the `;` separator and adds a regression test.

Repro
1. Set `notifications.argoproj.io/subscribe.my-trigger.slack: my-channel1;my-channel2;my-channel3`
2. Call `Unsubscribe("my-trigger", "slack", "my-channel2")`
3. On `master` you get `my-channel1my-channel3`
4. With this patch you get `my-channel1;my-channel3`
