### PR TITLE
feat(github): support payload field on Deployment notifications

### DIFF
--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -84,6 +84,8 @@ template.app-deployed: |
       autoMerge: true
       transientEnvironment: false
       reference: v1.0.0
+      payload: >-
+        {"image": "registry/app:{{.app.status.sync.revision}}"}
     pullRequestComment:
       content: |
         Application {{.app.metadata.name}} is now running new version of deployments manifests.

--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -77,6 +77,7 @@ type GitHubDeployment struct {
 	AutoMerge            *bool    `json:"autoMerge,omitempty"`
 	TransientEnvironment *bool    `json:"transientEnvironment,omitempty"`
 	Reference            string   `json:"reference,omitempty"`
+	Payload              string   `json:"payload,omitempty"`
 }
 
 type GitHubPullRequestComment struct {
@@ -141,7 +142,7 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 		}
 	}
 
-	var deploymentState, environment, environmentURL, reference, logURL *texttemplate.Template
+	var deploymentState, environment, environmentURL, reference, logURL, payload *texttemplate.Template
 	if g.Deployment != nil {
 		deploymentState, err = texttemplate.New(name).Funcs(f).Parse(g.Deployment.State)
 		if err != nil {
@@ -164,6 +165,11 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 		}
 
 		logURL, err = texttemplate.New(name).Funcs(f).Parse(g.Deployment.LogURL)
+		if err != nil {
+			return nil, err
+		}
+
+		payload, err = texttemplate.New(name).Funcs(f).Parse(g.Deployment.Payload)
 		if err != nil {
 			return nil, err
 		}
@@ -324,6 +330,12 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 			}
 			notification.GitHub.Deployment.Reference = referenceData.String()
 			notification.GitHub.Deployment.RequiredContexts = g.Deployment.RequiredContexts
+
+			var payloadData bytes.Buffer
+			if err := payload.Execute(&payloadData, vars); err != nil {
+				return err
+			}
+			notification.GitHub.Deployment.Payload = strings.TrimSpace(payloadData.String())
 		}
 
 		if g.PullRequestComment != nil {
@@ -596,17 +608,21 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 		if len(deployments) != 0 {
 			deployment = deployments[0]
 		} else {
+			deploymentReq := &github.DeploymentRequest{
+				Ref:                  &ref,
+				Environment:          &notification.GitHub.Deployment.Environment,
+				RequiredContexts:     &notification.GitHub.Deployment.RequiredContexts,
+				AutoMerge:            notification.GitHub.Deployment.AutoMerge,
+				TransientEnvironment: notification.GitHub.Deployment.TransientEnvironment,
+			}
+			if notification.GitHub.Deployment.Payload != "" {
+				deploymentReq.Payload = notification.GitHub.Deployment.Payload
+			}
 			deployment, _, err = g.client.GetRepositories().CreateDeployment(
 				context.Background(),
 				u[0],
 				u[1],
-				&github.DeploymentRequest{
-					Ref:                  &ref,
-					Environment:          &notification.GitHub.Deployment.Environment,
-					RequiredContexts:     &notification.GitHub.Deployment.RequiredContexts,
-					AutoMerge:            notification.GitHub.Deployment.AutoMerge,
-					TransientEnvironment: notification.GitHub.Deployment.TransientEnvironment,
-				},
+				deploymentReq,
 			)
 			if err != nil {
 				return err

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -133,6 +133,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 				RequiredContexts:     []string{},
 				AutoMerge:            &f,
 				TransientEnvironment: &tr,
+				Payload:              `{"image":"registry/app:{{.sync.status.lastSyncedCommit}}"}`,
 			},
 		},
 	}
@@ -171,6 +172,7 @@ func TestGetTemplater_GitHub_Deployment(t *testing.T) {
 	assert.Equal(t, &f, notification.GitHub.Deployment.AutoMerge)
 	assert.Equal(t, &tr, notification.GitHub.Deployment.TransientEnvironment)
 	assert.Equal(t, "v0.0.1", notification.GitHub.Deployment.Reference)
+	assert.JSONEq(t, `{"image":"registry/app:0123456789"}`, notification.GitHub.Deployment.Payload)
 }
 
 func TestNewGitHubService_GitHubOptions(t *testing.T) {
@@ -403,7 +405,8 @@ type mockPullRequestsService struct {
 }
 
 type mockRepositoriesService struct {
-	dispatches []github.DispatchRequestOptions
+	dispatches        []github.DispatchRequestOptions
+	lastDeploymentReq *github.DeploymentRequest
 }
 
 func (m *mockRepositoriesService) CreateStatus(_ context.Context, _, _, _ string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
@@ -414,7 +417,8 @@ func (m *mockRepositoriesService) ListDeployments(_ context.Context, _, _ string
 	return nil, nil, nil
 }
 
-func (m *mockRepositoriesService) CreateDeployment(_ context.Context, _, _ string, _ *github.DeploymentRequest) (*github.Deployment, *github.Response, error) {
+func (m *mockRepositoriesService) CreateDeployment(_ context.Context, _, _ string, req *github.DeploymentRequest) (*github.Deployment, *github.Response, error) {
+	m.lastDeploymentReq = req
 	return &github.Deployment{ID: github.Ptr(int64(1))}, nil, nil
 }
 
@@ -488,6 +492,52 @@ func TestGitHubService_Send_RepositoryDispatch(t *testing.T) {
 	payload, err := repos.dispatches[0].ClientPayload.MarshalJSON()
 	require.NoError(t, err)
 	assert.JSONEq(t, `{ "sha": "12345678" }`, string(payload))
+}
+
+func TestGitHubService_Send_Deployment_ForwardsPayload(t *testing.T) {
+	_, _, repos, client := setupMockServices()
+
+	service := &gitHubService{client: client}
+
+	err := service.Send(Notification{
+		GitHub: &GitHubNotification{
+			repoURL:  "https://github.com/owner/repo",
+			revision: "abc123",
+			Deployment: &GitHubDeployment{
+				State:       "success",
+				Environment: "production",
+				Reference:   "abc123",
+				Payload:     `{"image":"registry/app:1.2.3"}`,
+			},
+		},
+	}, Destination{})
+
+	require.NoError(t, err)
+	require.NotNil(t, repos.lastDeploymentReq)
+	require.NotNil(t, repos.lastDeploymentReq.Payload)
+	assert.JSONEq(t, `{"image":"registry/app:1.2.3"}`, repos.lastDeploymentReq.Payload.(string))
+}
+
+func TestGitHubService_Send_Deployment_OmitsEmptyPayload(t *testing.T) {
+	_, _, repos, client := setupMockServices()
+
+	service := &gitHubService{client: client}
+
+	err := service.Send(Notification{
+		GitHub: &GitHubNotification{
+			repoURL:  "https://github.com/owner/repo",
+			revision: "abc123",
+			Deployment: &GitHubDeployment{
+				State:       "success",
+				Environment: "production",
+				Reference:   "abc123",
+			},
+		},
+	}, Destination{})
+
+	require.NoError(t, err)
+	require.NotNil(t, repos.lastDeploymentReq)
+	assert.Nil(t, repos.lastDeploymentReq.Payload)
 }
 
 func TestGitHubService_Send_PullRequestCommentWithTag(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a templated `Payload` field on `GitHubDeployment` so trigger templates can carry deploy-time metadata (image tag, build id, etc.) into the GitHub deployment record. The field maps to GitHub's [`CreateDeployment` API](https://docs.github.com/en/rest/deployments/deployments#create-a-deployment) `payload` parameter — a JSON text the API explicitly exposes for this purpose, today silently dropped by notifications-engine.

## Why

Downstream consumers of the `deployment_status` event (workflows, Slack handlers, audit tooling) often need to know what was deployed (image tag, immutable artifact id). Without a templated `payload`, the field is always `{}` and consumers have to fall back to indirect lookups (e.g. `git tag --points-at <sha>`).

## Changes

- Add `Payload string` to `GitHubDeployment`.
- Parse and execute the field as a Go template in `GetTemplater`.
- Pass the rendered string to `DeploymentRequest.Payload` when present.
- Extend `TestGetTemplater_GitHub_Deployment` to cover templated payload rendering.
- Document the new field in `docs/services/github.md`.

## Example

```yaml
template.app-deployed: |
  github:
    repoURLPath: "{{.app.spec.source.repoURL}}"
    revisionPath: "{{.app.status.operationState.syncResult.revision}}"
    deployment:
      state: success
      environment: production
      payload: |
        {"image": "registry/app:{{.app.status.sync.revision}}"}
```

Closes #443