### PR TITLE
fix(github): make pullRequestComment commentTag templateable

### DIFF
--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -112,7 +112,7 @@ template.app-deployed: |
   Setting this option to `false` is required if you would like to deploy older refs in your default branch.
   For more information see the [GitHub Deployment API Docs](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment).
 - If `github.pullRequestComment.content` is set to 65536 characters or more, it will be truncated.
-- The `github.pullRequestComment.commentTag` parameter is used to identify the comment. If a comment with the specified tag is found, it will be updated (upserted). If no comment with the tag is found, a new comment will be created.
+- The `github.pullRequestComment.commentTag` parameter supports templating and is used to identify the comment. If a comment with the specified tag is found, it will be updated (upserted). If no comment with the tag is found, a new comment will be created.
 - Reference is optional. When set, it will be used as the ref to deploy. If not set, the revision will be used as the ref to deploy.
 
 ## Commit Statuses

--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -169,11 +169,18 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 		}
 	}
 
-	var pullRequestCommentContent *texttemplate.Template
+	var pullRequestCommentContent, pullRequestCommentTag *texttemplate.Template
 	if g.PullRequestComment != nil {
 		pullRequestCommentContent, err = texttemplate.New(name).Funcs(f).Parse(g.PullRequestComment.Content)
 		if err != nil {
 			return nil, err
+		}
+
+		if g.PullRequestComment.CommentTag != "" {
+			pullRequestCommentTag, err = texttemplate.New(name).Funcs(f).Parse(g.PullRequestComment.CommentTag)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -336,12 +343,24 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 				return err
 			}
 			notification.GitHub.PullRequestComment.Content = contentData.String()
-			notification.GitHub.PullRequestComment.CommentTag = g.PullRequestComment.CommentTag
 
-			if g.PullRequestComment.CommentTag != "" {
-				notification.GitHub.PullRequestComment.Content = fmt.Sprintf(contentFormat,
+			var commentTag string
+			if pullRequestCommentTag != nil {
+				var commentTagData bytes.Buffer
+				if err := pullRequestCommentTag.Execute(&commentTagData, vars); err != nil {
+					return err
+				}
+				commentTag = commentTagData.String()
+			}
+
+			notification.GitHub.PullRequestComment.CommentTag = commentTag
+
+			if commentTag != "" {
+				notification.GitHub.PullRequestComment.Content = fmt.Sprintf(
+					contentFormat,
 					notification.GitHub.PullRequestComment.Content,
-					fmt.Sprintf(commentTagFormat, g.PullRequestComment.CommentTag))
+					fmt.Sprintf(commentTagFormat, commentTag),
+				)
 			}
 		}
 

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -321,6 +321,44 @@ func TestGetTemplater_Github_PullRequestCommentWithTag(t *testing.T) {
 	assert.Equal(t, "This is a comment\n<!-- argocd-notifications test-tag -->", notification.GitHub.PullRequestComment.Content)
 }
 
+func TestGetTemplater_Github_PullRequestCommentWithTemplatedTag(t *testing.T) {
+	n := Notification{
+		GitHub: &GitHubNotification{
+			RepoURLPath:  "{{.sync.spec.git.repo}}",
+			RevisionPath: "{{.sync.status.lastSyncedCommit}}",
+			PullRequestComment: &GitHubPullRequestComment{
+				Content:    "This is a comment",
+				CommentTag: "preview/{{.app.metadata.name}}",
+			},
+		},
+	}
+	templater, err := n.GetTemplater("", template.FuncMap{})
+	require.NoError(t, err)
+
+	var notification Notification
+	err = templater(&notification, map[string]any{
+		"sync": map[string]any{
+			"spec": map[string]any{
+				"git": map[string]any{
+					"repo": "https://github.com/owner/repo",
+				},
+			},
+			"status": map[string]any{
+				"lastSyncedCommit": "abc123",
+			},
+		},
+		"app": map[string]any{
+			"metadata": map[string]any{
+				"name": "my-app",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "preview/my-app", notification.GitHub.PullRequestComment.CommentTag)
+	assert.Equal(t, "This is a comment\n<!-- argocd-notifications preview/my-app -->", notification.GitHub.PullRequestComment.Content)
+}
+
 func TestGitHubCheckRunNotification(t *testing.T) {
 	checkRun := &GitHubCheckRun{
 		Name:        "ArgoCD GitHub Check Run",


### PR DESCRIPTION
`docs/services/github.md` already shows templated `pullRequestComment.commentTag`, but the implementation currently treats `commentTag` as a literal string.

This causes multiple Argo CD Applications associated with the same PR to overwrite one another's comments instead of upserting independently.

This change renders `pullRequestComment.commentTag` through the Go templating engine, adds test coverage, and updates the GitHub service docs.

This is a partial fix for #355 and addresses the templateable `commentTag` portion of #433.
