### PR TITLE
docs: correct typos in the Notifications Engine docs

### DIFF
--- a/docs/services/googlechat.md
+++ b/docs/services/googlechat.md
@@ -2,7 +2,7 @@
 
 ## Parameters
 
-The Google Chat notification service send message notifications to a google chat webhook. This service uses the following settings:
+The Google Chat notification service sends message notifications to a Google Chat webhook. This service uses the following settings:
 
 * `webhooks` - a map of the form `webhookName: webhookUrl`
 
@@ -85,7 +85,7 @@ The card message can be written in JSON too.
 
 ## Chat Threads
 
-It is possible send both simple text and card messages in a chat thread by specifying a unique key for the thread. The thread key can be defined as follows:
+It is possible to send both simple text and card messages in a chat thread by specifying a unique key for the thread. The thread key can be defined as follows:
 
 ```yaml
 template.app-sync-succeeded: |

--- a/docs/services/rocketchat.md
+++ b/docs/services/rocketchat.md
@@ -4,8 +4,8 @@
 
 The Rocket.Chat notification service configuration includes following settings:
 
-* `email` - the Rocker.Chat user's SAMAccountName
-* `password` - the Rocker.Chat user's password
+* `email` - the Rocket.Chat user's SAMAccountName
+* `password` - the Rocket.Chat user's password
 * `alias` - optional alias that should be used to post message
 * `icon` - optional message icon
 * `avatar` - optional message avatar
@@ -18,11 +18,11 @@ The Rocket.Chat notification service configuration includes following settings:
 
 ![2](https://user-images.githubusercontent.com/15252187/115824993-7ccad900-a411-11eb-89de-6a0c4438ffdf.png)
 
-3. Add new user with `bot` role. Also note that `Require password change` checkbox mus be not checked
+3. Add new user with `bot` role. Also note that `Require password change` checkbox must not be checked
 
 ![3](https://user-images.githubusercontent.com/15252187/115825174-b4d21c00-a411-11eb-8f20-cda48cea9fad.png)
 
-4. Copy username and password that you was created for bot user
+4. Copy username and password that were created for bot user
 5. Create a public or private channel, or a team, for this example `my_channel`
 6. Add your bot to this channel **otherwise it won't work**
 7. Store email and password in argocd-notifications-secret Secret
@@ -52,7 +52,7 @@ data:
 
 9. Create a subscription for your Rocket.Chat integration:
 
-*Note: channel, team or user must be prefixed with # or @ elsewhere we will be interpretative destination as a room ID*
+*Note: channel, team or user must be prefixed with # or @, otherwise we will interpret the destination as a room ID*
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -37,7 +37,7 @@ func newTemplateNotifyCommand(cmdContext *commandContext) *cobra.Command {
 # Render notification render generated notification in console
 %s template notify app-sync-succeeded guestbook
 `, cmdContext.cliName, cmdContext.cliName),
-		Short: "Generates notification using the specified template and send it to specified recipients",
+		Short: "Generates notification using the specified template and sends it to specified recipients",
 		RunE: func(_ *cobra.Command, args []string) error {
 			cancel := withDebugLogs()
 			defer cancel()


### PR DESCRIPTION
hello! in argoproj/argo-cd#28169, i found some typos in the Notifications section of the Operator Manual. as i was working on PR argoproj/argo-cd#28187 to fix it, i discovered that some of those docs came from upstream in this repo. for that reason, i'm opening this PR too.