### PR TITLE
fix(subscriptions): resolve named services from subscription annotations

### DIFF
--- a/pkg/subscriptions/annotations.go
+++ b/pkg/subscriptions/annotations.go
@@ -69,7 +69,10 @@ func (a Annotations) iterate(callback func(trigger string, service string, recip
 			trigger := parts[0]
 			service := ""
 			if len(parts) >= 2 {
-				service = parts[1]
+				// Join the remaining segments so named services (e.g. "github.orgb",
+				// registered as service.github.orgb in the config) resolve correctly.
+				// Using only parts[1] dropped the name and broke the lookup.
+				service = strings.Join(parts[1:], ".")
 			} else {
 				service = parts[0]
 				trigger = ""

--- a/pkg/subscriptions/annotations_test.go
+++ b/pkg/subscriptions/annotations_test.go
@@ -74,6 +74,17 @@ func TestIterate(t *testing.T) {
 			key:        "notifications.argoproj.io/subscribe.slack",
 		},
 		{
+			// Named service (e.g. service.github.orgb in the config) must resolve from
+			// the subscription annotation; the name segment was previously dropped (#346).
+			annotations: map[string]string{
+				"notifications.argoproj.io/subscribe.on-sync.github.orgb": "my-recipient",
+			},
+			triggers:   []string{"on-sync"},
+			service:    []string{"github.orgb"},
+			recipients: []string{"my-recipient"},
+			key:        "notifications.argoproj.io/subscribe.on-sync.github.orgb",
+		},
+		{
 			annotations: map[string]string{
 				"notifications.argoproj.io/subscriptions": data,
 			},


### PR DESCRIPTION
Closes #346

## Problem
`iterate()` in `pkg/subscriptions/annotations.go` parses a subscription annotation key like `notifications.argoproj.io/subscribe.<trigger>.<service>` by splitting on `.` and taking `service = parts[1]`.

For a **named** service the name is dropped. Example: a service registered in the config as `service.github.orgb` (lookup key `github.orgb`) is subscribed with:

```
notifications.argoproj.io/subscribe.on-sync.github.orgb: my-recipient
```

The key splits to `[on-sync, github, orgb]`, so `parts[1]` is just `github`. Dispatch then looks up `github` (not registered) and fails with `notification service "github" is not supported`.

This breaks named services in general (`github.orgb`, `slack.teamA`, …) and is the root cause behind the multiple-GitHub-app-installation use case in #346.

## Fix
Join the remaining segments instead of taking only the second one:

```go
service = strings.Join(parts[1:], ".")
```

so the full name `github.orgb` is preserved and resolves to the registered config key. This matches the multi-segment service naming that `config.go` already supports. Backward compatible: existing two-segment keys (`subscribe.<trigger>.<service>`) are unchanged.

## Test
Extended `TestIterate` with a `subscribe.on-sync.github.orgb` case asserting the resolved service is `github.orgb`.

Proven as a real regression test:
- **Before the fix:** `TestIterate` fails — `Not equal: expected "github.orgb", actual "github"`.
- **After the fix:** passes.

`go build ./...` and `go vet ./pkg/subscriptions/` are clean.