### PR TITLE
feat(github): add workflow_dispatch to the GitHub notification service

### DIFF
--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -102,6 +102,14 @@ template.app-deployed: |
         text: |
           Application {{.app.metadata.name}} is now running new version of deployments manifests.
           See more here: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true
+    workflowDispatch:
+      workflow: deploy.yml
+      ref: "{{.app.spec.source.targetRevision}}"
+      inputs: |
+        {
+          "application": "{{.app.metadata.name}}",
+          "revision": "{{.app.status.operationState.syncResult.revision}}"
+        }
 ```
 
 **Notes**:
@@ -114,6 +122,7 @@ template.app-deployed: |
 - If `github.pullRequestComment.content` is set to 65536 characters or more, it will be truncated.
 - The `github.pullRequestComment.commentTag` parameter is used to identify the comment. If a comment with the specified tag is found, it will be updated (upserted). If no comment with the tag is found, a new comment will be created.
 - Reference is optional. When set, it will be used as the ref to deploy. If not set, the revision will be used as the ref to deploy.
+- `github.workflowDispatch` triggers a [workflow dispatch event](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event) for the given workflow. `workflow` is the workflow file name (for example `deploy.yml`) or its ID, `ref` is the branch or tag the workflow runs from, and `inputs` is an optional JSON object of workflow inputs. The GitHub App or token must have the `actions: write` permission.
 
 ## Commit Statuses
 

--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -43,6 +43,7 @@ type GitHubNotification struct {
 	RevisionPath       string                    `json:"revisionPath,omitempty"`
 	CheckRun           *GitHubCheckRun           `json:"checkRun,omitempty"`
 	RepositoryDispatch *GitHubRepositoryDispatch `json:"repositoryDispatch,omitempty"`
+	WorkflowDispatch   *GitHubWorkflowDispatch   `json:"workflowDispatch,omitempty"`
 }
 
 type GitHubStatus struct {
@@ -96,6 +97,16 @@ func (e *TooManyGitHubCommitStatusesError) Error() string {
 type GitHubRepositoryDispatch struct {
 	EventType     string `json:"event_type,omitempty"`
 	ClientPayload string `json:"client_payload,omitempty"`
+}
+
+type GitHubWorkflowDispatch struct {
+	// Workflow is the workflow file name (e.g. "deploy.yml") or workflow ID to trigger.
+	Workflow string `json:"workflow,omitempty"`
+	// Ref is the git reference (branch or tag name) the workflow runs from.
+	Ref string `json:"ref,omitempty"`
+	// Inputs is a JSON object of workflow inputs. It is templated and then
+	// decoded into the inputs map sent to GitHub.
+	Inputs string `json:"inputs,omitempty"`
 }
 
 const (
@@ -227,6 +238,22 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 			return nil, err
 		}
 		repoDispatchClientPayload, err = texttemplate.New(name).Funcs(f).Parse(g.RepositoryDispatch.ClientPayload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var workflowDispatchWorkflow, workflowDispatchRef, workflowDispatchInputs *texttemplate.Template
+	if g.WorkflowDispatch != nil {
+		workflowDispatchWorkflow, err = texttemplate.New(name).Funcs(f).Parse(g.WorkflowDispatch.Workflow)
+		if err != nil {
+			return nil, err
+		}
+		workflowDispatchRef, err = texttemplate.New(name).Funcs(f).Parse(g.WorkflowDispatch.Ref)
+		if err != nil {
+			return nil, err
+		}
+		workflowDispatchInputs, err = texttemplate.New(name).Funcs(f).Parse(g.WorkflowDispatch.Inputs)
 		if err != nil {
 			return nil, err
 		}
@@ -416,6 +443,25 @@ func (g *GitHubNotification) GetTemplater(name string, f texttemplate.FuncMap) (
 			notification.GitHub.RepositoryDispatch.ClientPayload = clientPayloadData.String()
 		}
 
+		if g.WorkflowDispatch != nil {
+			notification.GitHub.WorkflowDispatch = &GitHubWorkflowDispatch{}
+			var workflowData bytes.Buffer
+			if err := workflowDispatchWorkflow.Execute(&workflowData, vars); err != nil {
+				return err
+			}
+			notification.GitHub.WorkflowDispatch.Workflow = workflowData.String()
+			var refData bytes.Buffer
+			if err := workflowDispatchRef.Execute(&refData, vars); err != nil {
+				return err
+			}
+			notification.GitHub.WorkflowDispatch.Ref = refData.String()
+			var inputsData bytes.Buffer
+			if err := workflowDispatchInputs.Execute(&inputsData, vars); err != nil {
+				return err
+			}
+			notification.GitHub.WorkflowDispatch.Inputs = inputsData.String()
+		}
+
 		return nil
 	}, nil
 }
@@ -471,6 +517,7 @@ type githubClient interface {
 	GetPullRequests() pullRequestsService
 	GetRepositories() repositoriesService
 	GetChecks() checksService
+	GetActions() actionsService
 }
 
 type issuesService interface {
@@ -495,6 +542,10 @@ type checksService interface {
 	CreateCheckRun(ctx context.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, *github.Response, error)
 }
 
+type actionsService interface {
+	CreateWorkflowDispatchEventByFileName(ctx context.Context, owner, repo, workflowFileName string, event github.CreateWorkflowDispatchEventRequest) (*github.Response, error)
+}
+
 // Adapter implementation
 type githubClientAdapter struct {
 	client *github.Client
@@ -514,6 +565,10 @@ func (g *githubClientAdapter) GetRepositories() repositoriesService {
 
 func (g *githubClientAdapter) GetChecks() checksService {
 	return g.client.Checks
+}
+
+func (g *githubClientAdapter) GetActions() actionsService {
+	return g.client.Actions
 }
 
 func trunc(message string, n int) string {
@@ -783,6 +838,27 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 				EventType:     notification.GitHub.RepositoryDispatch.EventType,
 				ClientPayload: &payload,
 			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	if notification.GitHub.WorkflowDispatch != nil {
+		event := github.CreateWorkflowDispatchEventRequest{
+			Ref: notification.GitHub.WorkflowDispatch.Ref,
+		}
+		if inputs := notification.GitHub.WorkflowDispatch.Inputs; inputs != "" {
+			if err := json.Unmarshal([]byte(inputs), &event.Inputs); err != nil {
+				return err
+			}
+		}
+		_, err := g.client.GetActions().CreateWorkflowDispatchEventByFileName(
+			context.Background(),
+			u[0],
+			u[1],
+			notification.GitHub.WorkflowDispatch.Workflow,
+			event,
 		)
 		if err != nil {
 			return err

--- a/pkg/services/github_test.go
+++ b/pkg/services/github_test.go
@@ -290,6 +290,44 @@ func TestGetTemplater_Github_RepositoryDispatch(t *testing.T) {
 	assert.JSONEq(t, `{ "sha": "0123456789" }`, notification.GitHub.RepositoryDispatch.ClientPayload)
 }
 
+func TestGetTemplater_Github_WorkflowDispatch(t *testing.T) {
+	n := Notification{
+		GitHub: &GitHubNotification{
+			RepoURLPath:  "{{.sync.spec.git.repo}}",
+			RevisionPath: "{{.sync.status.lastSyncedCommit}}",
+			WorkflowDispatch: &GitHubWorkflowDispatch{
+				Workflow: "deploy.yml",
+				Ref:      "{{.sync.spec.git.branch}}",
+				Inputs:   `{ "sha": "{{.sync.status.lastSyncedCommit}}" }`,
+			},
+		},
+	}
+	templater, err := n.GetTemplater("", template.FuncMap{})
+
+	require.NoError(t, err)
+
+	var notification Notification
+	err = templater(&notification, map[string]any{
+		"sync": map[string]any{
+			"spec": map[string]any{
+				"git": map[string]any{
+					"repo":   "https://github.com/argoproj-labs/argocd-notifications.git",
+					"branch": "main",
+				},
+			},
+			"status": map[string]any{
+				"lastSyncedCommit": "0123456789",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, "deploy.yml", notification.GitHub.WorkflowDispatch.Workflow)
+	assert.Equal(t, "main", notification.GitHub.WorkflowDispatch.Ref)
+	assert.JSONEq(t, `{ "sha": "0123456789" }`, notification.GitHub.WorkflowDispatch.Inputs)
+}
+
 func TestGetTemplater_Github_PullRequestCommentWithTag(t *testing.T) {
 	n := Notification{
 		GitHub: &GitHubNotification{
@@ -438,29 +476,47 @@ func (m *mockChecksService) CreateCheckRun(_ context.Context, _, _ string, opts 
 	return &github.CheckRun{}, nil, nil
 }
 
+type workflowDispatchCall struct {
+	workflow string
+	event    github.CreateWorkflowDispatchEventRequest
+}
+
+type mockActionsService struct {
+	dispatches []workflowDispatchCall
+}
+
+func (m *mockActionsService) CreateWorkflowDispatchEventByFileName(_ context.Context, _, _, workflowFileName string, event github.CreateWorkflowDispatchEventRequest) (*github.Response, error) {
+	m.dispatches = append(m.dispatches, workflowDispatchCall{workflow: workflowFileName, event: event})
+	return nil, nil
+}
+
 // Mock client implementation
 type mockGitHubClientImpl struct {
-	issues *mockIssuesService
-	prs    *mockPullRequestsService
-	repos  *mockRepositoriesService
-	checks *mockChecksService
+	issues  *mockIssuesService
+	prs     *mockPullRequestsService
+	repos   *mockRepositoriesService
+	checks  *mockChecksService
+	actions *mockActionsService
 }
 
 func (m *mockGitHubClientImpl) GetIssues() issuesService             { return m.issues }
 func (m *mockGitHubClientImpl) GetPullRequests() pullRequestsService { return m.prs }
 func (m *mockGitHubClientImpl) GetRepositories() repositoriesService { return m.repos }
 func (m *mockGitHubClientImpl) GetChecks() checksService             { return m.checks }
+func (m *mockGitHubClientImpl) GetActions() actionsService           { return m.actions }
 
 func setupMockServices() (*mockIssuesService, *mockPullRequestsService, *mockRepositoriesService, githubClient) {
 	issues := &mockIssuesService{comments: []*github.IssueComment{}}
 	pulls := &mockPullRequestsService{prs: []*github.PullRequest{{Number: github.Ptr(1)}}}
 	repos := &mockRepositoriesService{}
 	checks := &mockChecksService{}
+	actions := &mockActionsService{}
 	client := &mockGitHubClientImpl{
-		issues: issues,
-		prs:    pulls,
-		repos:  repos,
-		checks: checks,
+		issues:  issues,
+		prs:     pulls,
+		repos:   repos,
+		checks:  checks,
+		actions: actions,
 	}
 	return issues, pulls, repos, client
 }
@@ -488,6 +544,31 @@ func TestGitHubService_Send_RepositoryDispatch(t *testing.T) {
 	payload, err := repos.dispatches[0].ClientPayload.MarshalJSON()
 	require.NoError(t, err)
 	assert.JSONEq(t, `{ "sha": "12345678" }`, string(payload))
+}
+
+func TestGitHubService_Send_WorkflowDispatch(t *testing.T) {
+	_, _, _, client := setupMockServices()
+	actions := client.(*mockGitHubClientImpl).actions
+
+	service := &gitHubService{client: client}
+
+	err := service.Send(Notification{
+		GitHub: &GitHubNotification{
+			repoURL:  "https://github.com/owner/repo",
+			revision: "abc123",
+			WorkflowDispatch: &GitHubWorkflowDispatch{
+				Workflow: "deploy.yml",
+				Ref:      "main",
+				Inputs:   `{ "environment": "prod" }`,
+			},
+		},
+	}, Destination{})
+
+	require.NoError(t, err)
+	require.Len(t, actions.dispatches, 1)
+	assert.Equal(t, "deploy.yml", actions.dispatches[0].workflow)
+	assert.Equal(t, "main", actions.dispatches[0].event.Ref)
+	assert.Equal(t, map[string]any{"environment": "prod"}, actions.dispatches[0].event.Inputs)
 }
 
 func TestGitHubService_Send_PullRequestCommentWithTag(t *testing.T) {


### PR DESCRIPTION
Closes #442

## What
Adds a `workflowDispatch` option to the GitHub notification service so a notification can trigger a [GitHub Actions workflow dispatch event](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event).

The service already supported `repository_dispatch` (#393); `workflow_dispatch` was the remaining half of #442.

## Usage
```yaml
template.app-deployed: |
  github:
    workflowDispatch:
      workflow: deploy.yml
      ref: "{{.app.spec.source.targetRevision}}"
      inputs: |
        {
          "application": "{{.app.metadata.name}}",
          "revision": "{{.app.status.operationState.syncResult.revision}}"
        }
```

- `workflow` — the workflow file name (e.g. `deploy.yml`) or its ID.
- `ref` — the branch or tag the workflow runs from.
- `inputs` — optional JSON object of workflow inputs (templated, then decoded into the inputs map).

The GitHub App / token needs the `actions: write` permission.

## Implementation
Mirrors the existing `repositoryDispatch` design end to end:
- New `GitHubWorkflowDispatch` struct + `workflowDispatch` field on `GitHubNotification`.
- Templater parses/executes `workflow`, `ref`, and `inputs` (the `inputs` JSON string is templated then `json.Unmarshal`-ed into the inputs map, just like `repositoryDispatch.clientPayload`).
- New `actionsService` interface + `GetActions()` on the `githubClient` interface and adapter, calling `Actions.CreateWorkflowDispatchEventByFileName` (go-github v69).
- Docs section + example.

## Tests
- `TestGetTemplater_Github_WorkflowDispatch` — verifies `workflow`, `ref`, and `inputs` template correctly.
- `TestGitHubService_Send_WorkflowDispatch` — verifies the dispatch is sent with the right workflow file, ref, and decoded inputs map.

`go build`, `go vet`, `gofmt`, and the full `pkg/services` test suite pass.