### PR TITLE
fix: persist Slack thread_ts across controller restarts

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,6 +20,10 @@ type GetVars func(obj map[string]any, dest services.Destination) map[string]any
 // API provides high level interface to send notifications and manage notification services
 type API interface {
 	Send(obj map[string]any, templates []string, dest services.Destination) error
+	// SendWithAnnotations behaves like Send but additionally returns any annotations that
+	// the notification service wants persisted onto the target resource (e.g. Slack thread
+	// state), so state survives controller restarts and leader-election failovers.
+	SendWithAnnotations(obj map[string]any, templates []string, dest services.Destination) (map[string]string, error)
 	RunTrigger(triggerName string, vars map[string]any) ([]triggers.ConditionResult, error)
 	AddNotificationService(name string, service services.NotificationService)
 	GetNotificationServices() map[string]services.NotificationService
@@ -50,9 +54,16 @@ func (n *api) GetNotificationServices() map[string]services.NotificationService 
 
 // Send sends notification using specified service and template to the specified destination
 func (n *api) Send(obj map[string]any, templates []string, dest services.Destination) error {
+	_, err := n.SendWithAnnotations(obj, templates, dest)
+	return err
+}
+
+// SendWithAnnotations behaves like Send but additionally returns any annotations that the
+// notification service wants persisted onto the target resource.
+func (n *api) SendWithAnnotations(obj map[string]any, templates []string, dest services.Destination) (map[string]string, error) {
 	notificationService, ok := n.notificationServices[dest.Service]
 	if !ok {
-		return fmt.Errorf("notification service '%s' is not supported", dest.Service)
+		return nil, fmt.Errorf("notification service '%s' is not supported", dest.Service)
 	}
 
 	vars := n.getVars(obj, dest)
@@ -65,10 +76,13 @@ func (n *api) Send(obj map[string]any, templates []string, dest services.Destina
 	in[recipientVarName] = dest.Recipient
 	notification, err := n.templatesService.FormatNotification(in, templates...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return notificationService.Send(*notification, dest)
+	if annotating, ok := notificationService.(services.AnnotatingNotificationService); ok {
+		return annotating.SendWithAnnotations(*notification, dest)
+	}
+	return nil, notificationService.Send(*notification, dest)
 }
 
 func (n *api) RunTrigger(triggerName string, obj map[string]any) ([]triggers.ConditionResult, error) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -192,6 +192,7 @@ func (c *notificationController) isSelfServiceConfigureApi(api api.API) bool {
 func (c *notificationController) processResourceWithAPI(api api.API, resource metav1.Object, logEntry *log.Entry, eventSequence *NotificationEventSequence) (map[string]string, error) {
 	apiNamespace := api.GetConfig().Namespace
 	notificationsState := NewStateFromRes(resource)
+	serviceAnnotations := map[string]string{}
 
 	destinations := c.getDestinations(resource, api.GetConfig())
 	if len(destinations) == 0 {
@@ -231,7 +232,13 @@ func (c *notificationController) processResourceWithAPI(api api.API, resource me
 					})
 				} else {
 					logEntry.Infof("Sending notification about condition '%s.%s' to '%v' using the configuration in namespace %s", trigger, cr.Key, to, apiNamespace)
-					if err := api.Send(un.Object, cr.Templates, to); err != nil {
+					toWithAnnotations := to
+					toWithAnnotations.Annotations = resource.GetAnnotations()
+					annotations, err := api.SendWithAnnotations(un.Object, cr.Templates, toWithAnnotations)
+					for k, v := range annotations {
+						serviceAnnotations[k] = v
+					}
+					if err != nil {
 						logEntry.Errorf("Failed to notify recipient %s defined in resource %s/%s: %v using the configuration in namespace %s",
 							to, resource.GetNamespace(), resource.GetName(), err, apiNamespace)
 
@@ -256,7 +263,17 @@ func (c *notificationController) processResourceWithAPI(api api.API, resource me
 		}
 	}
 
-	return notificationsState.Persist(resource)
+	annotations, err := notificationsState.Persist(resource)
+	if err != nil {
+		return nil, err
+	}
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	for k, v := range serviceAnnotations {
+		annotations[k] = v
+	}
+	return annotations, nil
 }
 
 func (c *notificationController) getDestinations(resource metav1.Object, cfg api.Config) services.Destinations {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -153,10 +153,12 @@ func TestSendsNotificationIfTriggered(t *testing.T) {
 	receivedObj := map[string]any{}
 	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
-	api.EXPECT().Send(mock.MatchedBy(func(obj map[string]any) bool {
+	api.EXPECT().SendWithAnnotations(mock.MatchedBy(func(obj map[string]any) bool {
 		receivedObj = obj
 		return true
-	}), []string{"test"}, services.Destination{Service: "mock", Recipient: "recipient"}).Return(nil)
+	}), []string{"test"}, mock.MatchedBy(func(dest services.Destination) bool {
+		return dest.Service == "mock" && dest.Recipient == "recipient"
+	})).Return(nil, nil)
 
 	annotations, err := ctrl.processResourceWithAPI(api, app, logEntry, &NotificationEventSequence{})
 	if err != nil {
@@ -211,7 +213,7 @@ func TestDoesNotSendNotificationIfTooManyCommitStatusesReceived(t *testing.T) {
 
 	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil).Times(2)
-	api.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(&services.TooManyGitHubCommitStatusesError{Sha: "sha", Context: "context"}).Times(1)
+	api.EXPECT().SendWithAnnotations(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &services.TooManyGitHubCommitStatusesError{Sha: "sha", Context: "context"}).Times(1)
 
 	// First attempt should hit the TooManyCommitStatusesError.
 	// Returned annotations1 should contain the information about processed notification
@@ -250,7 +252,7 @@ func TestRetriesNotificationIfSendThrows(t *testing.T) {
 
 	api.EXPECT().GetConfig().Return(notificationApi.Config{}).AnyTimes()
 	api.EXPECT().RunTrigger("my-trigger", gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil).Times(2)
-	api.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("boom")).Times(2)
+	api.EXPECT().SendWithAnnotations(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("boom")).Times(2)
 
 	// First attempt. The returned annotations should not contain the notification state due to the error.
 	annotations, err := ctrl.processResourceWithAPI(api, app, logEntry, &NotificationEventSequence{})
@@ -417,7 +419,7 @@ func TestWithEventCallback(t *testing.T) {
 			description: "EventCallback should be invoked with non-nil error on send failure",
 			sendErr:     errors.New("this is a send error"),
 			expectedErrors: []error{
-				fmt.Errorf("failed to deliver notification my-trigger to {mock recipient}: %w using the configuration in namespace ", errors.New("this is a send error")),
+				fmt.Errorf("failed to deliver notification my-trigger to {mock recipient map[]}: %w using the configuration in namespace ", errors.New("this is a send error")),
 			},
 		},
 		{
@@ -449,9 +451,11 @@ func TestWithEventCallback(t *testing.T) {
 
 			if tc.apiErr == nil {
 				api.EXPECT().RunTrigger(triggerName, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
-				api.EXPECT().Send(mock.MatchedBy(func(_ map[string]any) bool {
+				api.EXPECT().SendWithAnnotations(mock.MatchedBy(func(_ map[string]any) bool {
 					return true
-				}), []string{"test"}, destination).Return(tc.sendErr)
+				}), []string{"test"}, mock.MatchedBy(func(dest services.Destination) bool {
+					return dest.Service == destination.Service && dest.Recipient == destination.Recipient
+				})).Return(nil, tc.sendErr)
 			}
 
 			ctrl.processQueueItem()
@@ -490,10 +494,12 @@ func TestProcessResourceWithAPIWithSelfService(t *testing.T) {
 	// SelfService API: config has IsSelfServiceConfig set to true
 	api.EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: namespace}).AnyTimes()
 	api.EXPECT().RunTrigger(trigger, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
-	api.EXPECT().Send(mock.MatchedBy(func(obj map[string]any) bool {
+	api.EXPECT().SendWithAnnotations(mock.MatchedBy(func(obj map[string]any) bool {
 		receivedObj = obj
 		return true
-	}), []string{"test"}, services.Destination{Service: "mock", Recipient: "recipient"}).Return(nil)
+	}), []string{"test"}, mock.MatchedBy(func(dest services.Destination) bool {
+		return dest.Service == "mock" && dest.Recipient == "recipient"
+	})).Return(nil, nil)
 
 	annotations, err := ctrl.processResourceWithAPI(api, app, logEntry, &NotificationEventSequence{})
 	if err != nil {
@@ -530,15 +536,19 @@ func TestProcessItemsWithSelfService(t *testing.T) {
 	// SelfService API: config has IsSelfServiceConfig set to true
 	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: true, Namespace: "selfservice_namespace"}).Times(3)
 	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().RunTrigger(triggerName, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
-	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().Send(mock.MatchedBy(func(_ map[string]any) bool {
+	apiMap["selfservice_namespace"].(*mocks.MockAPI).EXPECT().SendWithAnnotations(mock.MatchedBy(func(_ map[string]any) bool {
 		return true
-	}), []string{"test"}, destination).Return(nil).AnyTimes()
+	}), []string{"test"}, mock.MatchedBy(func(dest services.Destination) bool {
+		return dest.Service == destination.Service && dest.Recipient == destination.Recipient
+	})).Return(nil, nil).AnyTimes()
 
 	apiMap["default"].(*mocks.MockAPI).EXPECT().GetConfig().Return(notificationApi.Config{IsSelfServiceConfig: false, Namespace: "default"}).Times(3)
 	apiMap["default"].(*mocks.MockAPI).EXPECT().RunTrigger(triggerName, gomock.Any()).Return([]triggers.ConditionResult{{Triggered: true, Templates: []string{"test"}}}, nil)
-	apiMap["default"].(*mocks.MockAPI).EXPECT().Send(mock.MatchedBy(func(_ map[string]any) bool {
+	apiMap["default"].(*mocks.MockAPI).EXPECT().SendWithAnnotations(mock.MatchedBy(func(_ map[string]any) bool {
 		return true
-	}), []string{"test"}, destination).Return(nil).AnyTimes()
+	}), []string{"test"}, mock.MatchedBy(func(dest services.Destination) bool {
+		return dest.Service == destination.Service && dest.Recipient == destination.Recipient
+	})).Return(nil, nil).AnyTimes()
 
 	ctrl.apiFactory = &mocks.FakeFactory{ApiMap: apiMap}
 
@@ -558,7 +568,8 @@ func TestProcessItemsWithSelfService(t *testing.T) {
 	}
 	for i, event := range actualSequence.Delivered {
 		assert.Equal(t, expectedDeliveries[i].Trigger, event.Trigger)
-		assert.Equal(t, expectedDeliveries[i].Destination, event.Destination)
+		assert.Equal(t, expectedDeliveries[i].Destination.Service, event.Destination.Service)
+		assert.Equal(t, expectedDeliveries[i].Destination.Recipient, event.Destination.Recipient)
 	}
 }
 

--- a/pkg/mocks/api.go
+++ b/pkg/mocks/api.go
@@ -104,3 +104,18 @@ func (mr *MockAPIMockRecorder) Send(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAPI)(nil).Send), arg0, arg1, arg2)
 }
+
+// SendWithAnnotations mocks base method.
+func (m *MockAPI) SendWithAnnotations(arg0 map[string]interface{}, arg1 []string, arg2 services.Destination) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendWithAnnotations", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendWithAnnotations indicates an expected call of SendWithAnnotations.
+func (mr *MockAPIMockRecorder) SendWithAnnotations(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendWithAnnotations", reflect.TypeOf((*MockAPI)(nil).SendWithAnnotations), arg0, arg1, arg2)
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -44,11 +44,14 @@ func (s Destinations) Merge(other Destinations) {
 
 func (s Destinations) Dedup() Destinations {
 	for k, v := range s {
-		set := map[Destination]bool{}
+		set := map[string]bool{}
 		var dedup []Destination
 		for _, dest := range v {
-			if !set[dest] {
-				set[dest] = true
+			// \x00 can't appear in Service/Recipient, so it safely delimits them to avoid
+			// key collisions like ("ab", "c") vs ("a", "bc").
+			key := dest.Service + "\x00" + dest.Recipient
+			if !set[key] {
+				set[key] = true
 				dedup = append(dedup, dest)
 			}
 		}
@@ -61,6 +64,11 @@ func (s Destinations) Dedup() Destinations {
 type Destination struct {
 	Service   string `json:"service"`
 	Recipient string `json:"recipient"`
+	// Annotations holds a read-only snapshot of the target resource's annotations at the
+	// time the notification is sent. Services that need to persist state across process
+	// restarts (e.g. Slack thread timestamps) can use it to rehydrate that state; see
+	// AnnotatingNotificationService.
+	Annotations map[string]string `json:"-"`
 }
 
 func (n *Notification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
@@ -121,6 +129,16 @@ func (n *Notification) GetTemplater(name string, f texttemplate.FuncMap) (Templa
 // NotificationService defines notification service interface
 type NotificationService interface {
 	Send(notification Notification, dest Destination) error
+}
+
+// AnnotatingNotificationService is an optional extension of NotificationService for services
+// that need to persist state across process restarts (e.g. Slack thread timestamps used to
+// keep grouped notifications in the same thread). Implementations read prior state from
+// dest.Annotations and return the annotations that should be persisted back onto the target
+// resource so the state survives controller restarts and leader-election failovers.
+type AnnotatingNotificationService interface {
+	NotificationService
+	SendWithAnnotations(notification Notification, dest Destination) (map[string]string, error)
 }
 
 // HandleSendError inspects the error and signals the caller if the Send operation should be retried.

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -8,6 +8,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDestinations_Merge(t *testing.T) {
+	a := Destinations{"trigger1": {{Service: "slack", Recipient: "a"}}}
+	b := Destinations{
+		"trigger1": {{Service: "slack", Recipient: "b"}},
+		"trigger2": {{Service: "email", Recipient: "c"}},
+	}
+
+	a.Merge(b)
+
+	assert.Equal(t, Destinations{
+		"trigger1": {{Service: "slack", Recipient: "a"}, {Service: "slack", Recipient: "b"}},
+		"trigger2": {{Service: "email", Recipient: "c"}},
+	}, a)
+}
+
+func TestDestinations_Dedup(t *testing.T) {
+	d := Destinations{
+		"trigger1": {
+			{Service: "slack", Recipient: "a"},
+			{Service: "slack", Recipient: "a"},
+			{Service: "slack", Recipient: "b"},
+			{Service: "email", Recipient: "a"},
+		},
+	}
+
+	deduped := d.Dedup()
+
+	assert.Equal(t, Destinations{
+		"trigger1": {
+			{Service: "slack", Recipient: "a"},
+			{Service: "slack", Recipient: "b"},
+			{Service: "email", Recipient: "a"},
+		},
+	}, deduped)
+}
+
 func TestGetTemplater(t *testing.T) {
 	n := Notification{Message: "{{.foo}}"}
 

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -18,7 +18,15 @@ import (
 )
 
 // No rate limit unless Slack requests it (allows for Slack to control bursting)
-var slackState = slackutil.NewState(rate.NewLimiter(rate.Inf, 1))
+var slackLimiter = rate.NewLimiter(rate.Inf, 1)
+
+// slackThreadStateAnnotationKey is the annotation used to persist Slack thread timestamps
+// (groupingKey -> thread_ts) on the target resource, so threading survives controller
+// restarts and leader-election failovers. Without this, thread state only lives in an
+// in-memory map and is lost on restart, causing grouped notifications to start a new
+// top-level thread instead of replying to the existing one.
+// See https://github.com/argoproj/argo-rollouts/issues/4809.
+const slackThreadStateAnnotationKey = "notifications.argoproj.io/slack-thread-state"
 
 type SlackNotification struct {
 	Username        string                   `json:"username,omitempty"`
@@ -170,17 +178,29 @@ func buildMessageOptions(notification Notification, opts SlackOptions) (*SlackNo
 }
 
 func (s *slackService) Send(notification Notification, dest Destination) error {
+	_, err := s.SendWithAnnotations(notification, dest)
+	return err
+}
+
+// SendWithAnnotations sends the Slack notification and returns the annotations that should be
+// persisted on the target resource so thread state (groupingKey -> thread_ts) survives
+// controller restarts and leader-election failovers. Callers that don't persist the returned
+// annotations back onto the resource will fall back to per-process, in-memory-only threading,
+// same as before this method existed.
+func (s *slackService) SendWithAnnotations(notification Notification, dest Destination) (map[string]string, error) {
 	slackNotification, msgOptions, err := buildMessageOptions(notification, s.opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	client, err := newSlackClient(s.opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return slackutil.NewThreadedClient(
+
+	state := slackutil.NewStateFromJSON(slackLimiter, dest.Annotations[slackThreadStateAnnotationKey])
+	sendErr := slackutil.NewThreadedClient(
 		client,
-		slackState,
+		state,
 	).SendMessage(
 		context.TODO(),
 		dest.Recipient,
@@ -189,6 +209,17 @@ func (s *slackService) Send(notification Notification, dest Destination) error {
 		slackNotification.DeliveryPolicy,
 		msgOptions,
 	)
+
+	snapshot, exportErr := state.Export()
+	if exportErr != nil {
+		if sendErr != nil {
+			return nil, sendErr
+		}
+		return nil, exportErr
+	}
+
+	annotations := map[string]string{slackThreadStateAnnotationKey: snapshot}
+	return annotations, sendErr
 }
 
 // GetSigningSecret exposes signing secret for slack bot

--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -559,6 +559,93 @@ func TestSlack_SetUsernameAndIcon(t *testing.T) {
 	})
 }
 
+// TestSlack_ThreadPersistsAcrossRestart reproduces and verifies the fix for
+// https://github.com/argoproj/argo-rollouts/issues/4809: Slack thread continuity for a given
+// groupingKey used to be lost whenever the controller process serving notifications restarted
+// (pod restart, leader-election failover), because thread_ts only lived in an in-memory map.
+//
+// This test drives slackService exactly like the controller does: it sends a first message,
+// captures the annotations SendWithAnnotations asks the caller to persist, then simulates a
+// full restart by constructing a brand new slackService (equivalent to a new process/pod) and
+// feeding it only those persisted annotations via dest.Annotations. The second message must
+// still be posted as a threaded reply (ts option set, same thread) instead of a new top-level
+// message.
+func TestSlack_ThreadPersistsAcrossRestart(t *testing.T) {
+	const groupingKey = "my-group"
+	const channel = "test-channel"
+
+	firstResponse, err := json.Marshal(chatResponseFull{
+		Channel:          channel,
+		Timestamp:        "1503435956.000247",
+		MessageTimeStamp: "1503435956.000247",
+		Text:             "first",
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		_, err := writer.Write(firstResponse)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	opts := SlackOptions{
+		ApiURL:             server.URL + "/",
+		Token:              "something-token",
+		InsecureSkipVerify: true,
+	}
+
+	// First message, sent by the "original" process. No prior state.
+	service1 := NewSlackService(opts).(*slackService)
+	annotations, err := service1.SendWithAnnotations(
+		Notification{
+			Message: "first",
+			Slack:   &SlackNotification{GroupingKey: groupingKey},
+		},
+		Destination{Recipient: channel, Service: "slack"},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, annotations[slackThreadStateAnnotationKey],
+		"SendWithAnnotations must return thread state for the caller to persist onto the resource")
+
+	// Simulate a controller restart / leader-election failover: a brand new slackService is
+	// constructed (as happens in a fresh process), and the only thing carried over is the
+	// annotation the previous process asked to persist - exactly what the controller does by
+	// storing the returned map on the resource and passing it back in via dest.Annotations on
+	// the next reconcile.
+	service2 := NewSlackService(opts).(*slackService)
+
+	var capturedBody string
+	server.Config.Handler = http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		data, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		capturedBody = string(data)
+		writer.WriteHeader(http.StatusOK)
+		_, err = writer.Write(firstResponse)
+		require.NoError(t, err)
+	})
+
+	err = service2.Send(
+		Notification{
+			Message: "second",
+			Slack:   &SlackNotification{GroupingKey: groupingKey},
+		},
+		Destination{
+			Recipient:   channel,
+			Service:     "slack",
+			Annotations: annotations,
+		},
+	)
+	require.NoError(t, err)
+
+	values, err := url.ParseQuery(capturedBody)
+	require.NoError(t, err)
+	assert.Equal(t, "1503435956.000247", values.Get("thread_ts"),
+		"BUG REPRODUCED IF THIS FAILS: after a simulated restart, the second message for the "+
+			"same groupingKey did not include thread_ts, so it would start a new top-level "+
+			"thread instead of replying to the original one")
+}
+
 func TestSlack_SendNotification_WithInvalidJSON(t *testing.T) {
 	service := NewSlackService(SlackOptions{
 		Token:              "something-token",

--- a/pkg/util/slack/client.go
+++ b/pkg/util/slack/client.go
@@ -81,6 +81,45 @@ func NewState(limiter *rate.Limiter) *state {
 	}
 }
 
+type stateSnapshot struct {
+	ThreadTSs  timestampMap
+	ChannelIDs channelMap
+}
+
+// NewStateFromJSON creates a state seeded with a previously exported ThreadTSs/ChannelIDs
+// snapshot (see (*state).Export), so thread continuity survives process restarts. An empty
+// or invalid snapshot results in an empty state, same as NewState.
+func NewStateFromJSON(limiter *rate.Limiter, snapshot string) *state {
+	s := NewState(limiter)
+	if snapshot == "" {
+		return s
+	}
+	var exported stateSnapshot
+	if err := json.Unmarshal([]byte(snapshot), &exported); err != nil {
+		return s
+	}
+	if exported.ThreadTSs != nil {
+		s.ThreadTSs = exported.ThreadTSs
+	}
+	if exported.ChannelIDs != nil {
+		s.ChannelIDs = exported.ChannelIDs
+	}
+	return s
+}
+
+// Export serializes the ThreadTSs/ChannelIDs so they can be persisted (e.g. as a resource
+// annotation) and later restored via NewStateFromJSON.
+func (s *state) Export() (string, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	bs, err := json.Marshal(stateSnapshot{s.ThreadTSs, s.ChannelIDs})
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}
+
 type threadedClient struct {
 	Client SlackClient
 	*state

--- a/pkg/util/slack/client_test.go
+++ b/pkg/util/slack/client_test.go
@@ -90,6 +90,30 @@ func EqChatPost() gomock.Matcher {
 	return slackAPIMethodMatcher{"chat.postMessage"}
 }
 
+func TestState_ExportAndRestore(t *testing.T) {
+	s := NewState(rate.NewLimiter(rate.Inf, 1))
+	s.ThreadTSs["channel"] = map[string]string{"group": "123.456"}
+	s.ChannelIDs["channel"] = "channel-ID"
+
+	snapshot, err := s.Export()
+	require.NoError(t, err)
+	assert.NotEmpty(t, snapshot)
+
+	restored := NewStateFromJSON(rate.NewLimiter(rate.Inf, 1), snapshot)
+	assert.Equal(t, s.ThreadTSs, restored.ThreadTSs)
+	assert.Equal(t, s.ChannelIDs, restored.ChannelIDs)
+}
+
+func TestNewStateFromJSON_EmptyOrInvalid(t *testing.T) {
+	empty := NewStateFromJSON(rate.NewLimiter(rate.Inf, 1), "")
+	assert.Empty(t, empty.ThreadTSs)
+	assert.Empty(t, empty.ChannelIDs)
+
+	invalid := NewStateFromJSON(rate.NewLimiter(rate.Inf, 1), "not-json")
+	assert.Empty(t, invalid.ThreadTSs)
+	assert.Empty(t, invalid.ChannelIDs)
+}
+
 func TestThreadedClient(t *testing.T) {
 	const (
 		groupingKey string = "group"


### PR DESCRIPTION
Slack thread continuity (groupingKey -> thread_ts) previously lived only in an in-memory map, so a controller restart or leader-election failover reset it and grouped notifications started a new top-level thread instead of replying to the existing one.

Adds AnnotatingNotificationService, an optional NotificationService extension that returns annotations the caller should persist onto the target resource. The Slack service implements it, seeding/exporting its thread state via Destination.Annotations instead of a package-global in-memory map. The controller wires the resource's annotations in before sending and merges the returned annotations back in when persisting state, the same way NotificationsState already does for delivery dedup.

Fixes argoproj/argo-rollouts#4809