### PR TITLE
fix(webhook): route retryablehttp logging through logrus

### DIFF
--- a/pkg/services/webhook.go
+++ b/pkg/services/webhook.go
@@ -179,6 +179,9 @@ func (r *request) execute(service *webhookService) (*http.Response, error) {
 
 	client := retryablehttp.NewClient()
 	client.HTTPClient = whclient
+	// without this retryablehttp logs "[DEBUG] <method> <url>" to stderr for every request,
+	// ignoring the configured log level
+	client.Logger = httputil.NewRetryableHTTPLogger(r.destService)
 	client.RetryWaitMin = service.opts.RetryWaitMin
 	client.RetryWaitMax = service.opts.RetryWaitMax
 	client.RetryMax = service.opts.RetryMax

--- a/pkg/util/http/retryablelogger.go
+++ b/pkg/util/http/retryablelogger.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-retryablehttp"
+	log "github.com/sirupsen/logrus"
+)
+
+// NewRetryableHTTPLogger adapts logrus to retryablehttp.LeveledLogger.
+//
+// retryablehttp.NewClient defaults to its own stdlib logger, which prints
+// "[DEBUG] <method> <url>" to stderr for every request. That bypasses the configured logrus
+// level entirely, so the line cannot be turned off, and it puts the full request URL - including
+// any credential carried in a query parameter - into the controller log. Requests are already
+// logged at debug level by NewLoggingRoundTripper, so this keeps retryablehttp's own output on
+// the same logger and under the same level.
+func NewRetryableHTTPLogger(serviceName string) retryablehttp.LeveledLogger {
+	return &retryableHTTPLogger{entry: log.WithField("service", serviceName)}
+}
+
+type retryableHTTPLogger struct {
+	entry *log.Entry
+}
+
+func (l *retryableHTTPLogger) Error(msg string, keysAndValues ...any) {
+	l.withFields(keysAndValues).Error(msg)
+}
+
+func (l *retryableHTTPLogger) Warn(msg string, keysAndValues ...any) {
+	l.withFields(keysAndValues).Warn(msg)
+}
+
+func (l *retryableHTTPLogger) Info(msg string, keysAndValues ...any) {
+	l.withFields(keysAndValues).Info(msg)
+}
+
+func (l *retryableHTTPLogger) Debug(msg string, keysAndValues ...any) {
+	l.withFields(keysAndValues).Debug(msg)
+}
+
+// withFields turns retryablehttp's alternating key/value varargs into logrus fields. A trailing
+// key without a value is dropped.
+func (l *retryableHTTPLogger) withFields(keysAndValues []any) *log.Entry {
+	if len(keysAndValues) < 2 {
+		return l.entry
+	}
+	fields := make(log.Fields, len(keysAndValues)/2)
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		fields[fmt.Sprint(keysAndValues[i])] = keysAndValues[i+1]
+	}
+	return l.entry.WithFields(fields)
+}

--- a/pkg/util/http/retryablelogger_test.go
+++ b/pkg/util/http/retryablelogger_test.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryableHTTPLogger_HonoursLogLevel(t *testing.T) {
+	// exercises the constructor, so this covers the global logger the webhook service gets
+	hook := logtest.NewGlobal()
+	level := log.GetLevel()
+	log.SetOutput(io.Discard)
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetLevel(level)
+		log.SetOutput(os.Stderr)
+	})
+
+	l := NewRetryableHTTPLogger("webhook")
+
+	// this is the call retryablehttp makes for every request
+	l.Debug("performing request", "method", "POST", "url", "https://example.com/invoke?sig=secret")
+	assert.Empty(t, hook.AllEntries(), "debug output must not be emitted at info level")
+
+	log.SetLevel(log.DebugLevel)
+	l.Debug("performing request", "method", "POST")
+	require.Len(t, hook.AllEntries(), 1)
+	assert.Equal(t, "webhook", hook.LastEntry().Data["service"])
+	assert.Equal(t, "POST", hook.LastEntry().Data["method"])
+}
+
+func TestRetryableHTTPLogger_MapsLevelsAndFields(t *testing.T) {
+	logger, hook := logtest.NewNullLogger()
+	logger.SetLevel(log.DebugLevel)
+	l := &retryableHTTPLogger{entry: logger.WithField("service", "webhook")}
+
+	l.Debug("performing request", "method", "POST")
+	l.Info("retrying request", "remaining", 2)
+	l.Warn("unexpected HTTP status", "status", "502")
+	l.Error("request failed", "error", "connection refused")
+
+	entries := hook.AllEntries()
+	require.Len(t, entries, 4)
+
+	assert.Equal(t, log.DebugLevel, entries[0].Level)
+	assert.Equal(t, "performing request", entries[0].Message)
+	assert.Equal(t, "webhook", entries[0].Data["service"])
+	assert.Equal(t, "POST", entries[0].Data["method"])
+
+	assert.Equal(t, log.InfoLevel, entries[1].Level)
+	assert.Equal(t, 2, entries[1].Data["remaining"])
+
+	assert.Equal(t, log.WarnLevel, entries[2].Level)
+	assert.Equal(t, "502", entries[2].Data["status"])
+
+	assert.Equal(t, log.ErrorLevel, entries[3].Level)
+	assert.Equal(t, "connection refused", entries[3].Data["error"])
+}
+
+func TestRetryableHTTPLogger_ToleratesOddVarargs(t *testing.T) {
+	logger, hook := logtest.NewNullLogger()
+	logger.SetLevel(log.DebugLevel)
+	l := &retryableHTTPLogger{entry: logger.WithField("service", "webhook")}
+
+	l.Debug("no pairs at all")
+	l.Debug("dangling key", "method")
+	l.Debug("pair plus dangling key", "method", "POST", "url")
+
+	entries := hook.AllEntries()
+	require.Len(t, entries, 3)
+	assert.Equal(t, log.Fields{"service": "webhook"}, entries[0].Data)
+	assert.Equal(t, log.Fields{"service": "webhook"}, entries[1].Data)
+	assert.Equal(t, log.Fields{"service": "webhook", "method": "POST"}, entries[2].Data)
+}


### PR DESCRIPTION
### Problem

`retryablehttp.NewClient()` defaults to its own stdlib logger ([`client.go:443`](https://github.com/hashicorp/go-retryablehttp/blob/main/client.go#L443)), and the webhook service never overrides it. So every notification produces this on stderr:

```
2026/07/28 12:24:18 [DEBUG] POST https://…/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<signature>
```

Two problems with it:

1. **It cannot be turned off.** The line goes through the stdlib logger, not logrus, so ArgoCD's `--loglevel` has no effect on it. You can see it in the format — stdlib `2026/07/28 12:24:18 …` next to the JSON logrus lines from everything else.
2. **It logs credentials.** `redactURL` only strips `user:pass@` userinfo, not query parameters. Microsoft Power Automate Workflows webhooks — the replacement for the Office 365 connectors that `service.teams` targets, retired in May 2026 — carry their authentication as a `sig` query parameter. Anyone migrating a Teams notification to `service.webhook` now ships that signature to the controller log, and from there into whatever aggregates it.

It is also redundant: `NewServiceHTTPClient` already wraps the transport in `NewLoggingRoundTripper`, which logs the request at logrus debug level.

### Change

Adapt logrus to `retryablehttp.LeveledLogger` and hand it to the client, so retryablehttp's output lands on the same logger and under the same level as the rest of the engine. `[DEBUG] POST …` becomes a logrus debug entry — silent at info, still there when you ask for debug. Retry and failure messages are preserved rather than discarded (which is what `client.Logger = nil` would have done).

### Test

`pkg/util/http/retryablelogger_test.go` covers the behaviour that motivated the change — a `Debug` call emits nothing at info level — plus level/field mapping and odd-length varargs.

```
go test ./pkg/util/http/... ./pkg/services/...
ok  github.com/argoproj/notifications-engine/pkg/util/http     0.368s
ok  github.com/argoproj/notifications-engine/pkg/services      7.564s
```
