### PR TITLE
feat(rocketchat): add incoming webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Notifications Engine
 
 Notifications Engine is a configuration-driven Golang library that provides notifications for cloud-native applications.
-The project provides integration with dozen of services like Slack, MS Teams, Mattermost, SMTP, Telegram, Netgenie, and the list keeps growing.
+The project provides integration with dozen of services like Slack, MS Teams, Mattermost, Rocket.Chat, SMTP, Telegram, Netgenie, and the list keeps growing.
 
 <p align="center">
 <img width="460" src="https://user-images.githubusercontent.com/426437/115815221-70139a00-a3ab-11eb-8dc9-3e15f6b17804.png">

--- a/docs/services/rocketchat.md
+++ b/docs/services/rocketchat.md
@@ -4,14 +4,50 @@
 
 The Rocket.Chat notification service configuration includes following settings:
 
-* `email` - the Rocker.Chat user's SAMAccountName
-* `password` - the Rocker.Chat user's password
+* `email` - the Rocker.Chat user's SAMAccountName (login mode only)
+* `password` - the Rocker.Chat user's password (login mode only)
+* `webhookUrl` - Incoming Webhook URL (webhook mode only, see below). Takes precedence over `email`/`password` if set
 * `alias` - optional alias that should be used to post message
 * `icon` - optional message icon
 * `avatar` - optional message avatar
-* `serverUrl` - optional Rocket.Chat server url
+* `serverUrl` - optional Rocket.Chat server url (login mode only)
+* `insecureSkipVerify` - optional, skip TLS certificate verification (webhook mode only)
 
-## Configuration
+## Webhook configuration (recommended)
+
+Using an Incoming Webhook avoids storing a bot user's password entirely and is the recommended way to integrate. TLS to a self-hosted instance behind an internal CA is supported the same way as the other webhook-based services (Teams, Mattermost).
+
+1. Login to your Rocket.Chat instance as admin
+2. Go to **Administration > Integrations > New > Incoming Webhook**
+3. Enable it, pick the default channel, and save
+4. *(Optional, only if you need per-application channels)* enable **"Allow to overwrite destination channel in the body parameters"** on the integration. Without this, Rocket.Chat silently ignores the `channel` this library sends and every notification lands on the integration's fixed default channel, regardless of what's set on the `notifications.argoproj.io/subscribe...` annotation. This setting is opt-in because an unrestricted override lets any webhook caller post into channels/DMs it wasn't meant to reach — only enable it if you trust everything that can call this webhook URL.
+5. Copy the generated Webhook URL
+6. Store it in the `argocd-notifications-secret` Secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret-name>
+stringData:
+  rocketchat-webhook-url: <webhook-url>
+```
+
+7. Configure the integration in the `argocd-notifications-cm` config map:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+data:
+  service.rocketchat: |
+    webhookUrl: $rocketchat-webhook-url
+```
+
+8. Create a subscription for your Rocket.Chat integration, same as in login mode (see below). The channel/user set on the subscription only takes effect if step 4 above was done; otherwise it's ignored and the message always goes to the integration's default channel.
+
+## Login configuration (user/password)
 
 1. Login to your RocketChat instance
 2. Go to user management

--- a/pkg/services/rocketchat.go
+++ b/pkg/services/rocketchat.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -13,6 +15,8 @@ import (
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/rest"
 	log "github.com/sirupsen/logrus"
+
+	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
 )
 
 type RocketChatNotification struct {
@@ -40,12 +44,16 @@ func (n *RocketChatNotification) GetTemplater(name string, f texttemplate.FuncMa
 }
 
 type RocketChatOptions struct {
-	Alias     string `json:"alias"`
-	Email     string `json:"email"`
-	Password  string `json:"password"`
-	Icon      string `json:"icon"`
-	Avatar    string `json:"avatar"`
-	ServerUrl string `json:"serverUrl"`
+	Alias      string `json:"alias"`
+	Email      string `json:"email"`
+	Password   string `json:"password"`
+	Icon       string `json:"icon"`
+	Avatar     string `json:"avatar"`
+	ServerUrl  string `json:"serverUrl"`
+	WebhookUrl string `json:"webhookUrl"`
+
+	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+	httputil.TransportOptions
 }
 
 type rocketChatService struct {
@@ -59,6 +67,10 @@ func NewRocketChatService(opts RocketChatOptions) NotificationService {
 }
 
 func (r *rocketChatService) Send(notification Notification, dest Destination) error {
+	if r.opts.WebhookUrl != "" {
+		return r.sendWebhook(notification, dest)
+	}
+
 	serverUrl, err := url.Parse(r.opts.ServerUrl)
 	if err != nil {
 		return err
@@ -114,6 +126,86 @@ func (r *rocketChatService) Send(notification Notification, dest Destination) er
 	}
 
 	return err
+}
+
+type rocketChatWebhookPayload struct {
+	Text        string              `json:"text"`
+	Alias       string              `json:"alias,omitempty"`
+	Emoji       string              `json:"emoji,omitempty"`
+	Avatar      string              `json:"avatar,omitempty"`
+	Channel     string              `json:"channel,omitempty"`
+	Attachments []models.Attachment `json:"attachments,omitempty"`
+}
+
+func (r *rocketChatService) sendWebhook(notification Notification, dest Destination) error {
+	payload := rocketChatWebhookPayload{
+		Text:  notification.Message,
+		Alias: r.opts.Alias,
+	}
+
+	if strings.HasPrefix(dest.Recipient, "#") || strings.HasPrefix(dest.Recipient, "@") {
+		payload.Channel = dest.Recipient
+	} else if dest.Recipient != "" {
+		payload.Channel = "#" + dest.Recipient
+	}
+
+	if r.opts.Icon != "" {
+		if validEmoji.MatchString(r.opts.Icon) {
+			payload.Emoji = r.opts.Icon
+		} else {
+			log.Warnf("Icon reference '%v' is not a valid emoji", r.opts.Icon)
+		}
+	}
+	if r.opts.Avatar != "" {
+		if isValidAvatarURL(r.opts.Avatar) {
+			payload.Avatar = r.opts.Avatar
+		} else {
+			log.Warnf("Avatar reference '%v' is not a valid URL", r.opts.Avatar)
+		}
+	}
+
+	if notification.RocketChat != nil && notification.RocketChat.Attachments != "" {
+		attachments := make([]models.Attachment, 0)
+		if err := json.Unmarshal([]byte(notification.RocketChat.Attachments), &attachments); err != nil {
+			return fmt.Errorf("failed to unmarshal attachments '%s' : %w", notification.RocketChat.Attachments, err)
+		}
+		payload.Attachments = attachments
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	client, err := httputil.NewServiceHTTPClient(r.opts.TransportOptions, r.opts.InsecureSkipVerify, r.opts.WebhookUrl, "rocketchat")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, r.opts.WebhookUrl, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to request: %w", err)
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body: %w", err)
+	}
+
+	if res.StatusCode/100 != 2 {
+		return fmt.Errorf("rocketchat webhook post error %d : %s", res.StatusCode, string(data))
+	}
+
+	return nil
 }
 
 func isValidAvatarURL(iconURL string) bool {

--- a/pkg/services/rocketchat_test.go
+++ b/pkg/services/rocketchat_test.go
@@ -61,6 +61,74 @@ func TestSend_RocketChatWebhook(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSend_RocketChatWebhook_ChannelAlreadyPrefixed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"text": "message", "channel": "@someuser"}`, string(b))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	service := NewRocketChatService(RocketChatOptions{WebhookUrl: ts.URL})
+	err := service.Send(Notification{Message: "message"}, Destination{Recipient: "@someuser"})
+	require.NoError(t, err)
+}
+
+func TestSend_RocketChatWebhook_InvalidIconAndAvatarAreIgnored(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"text": "message", "channel": "#chan"}`, string(b))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	service := NewRocketChatService(RocketChatOptions{
+		WebhookUrl: ts.URL,
+		Icon:       "not-an-emoji",
+		Avatar:     "not-a-url",
+	})
+	err := service.Send(Notification{Message: "message"}, Destination{Recipient: "#chan"})
+	require.NoError(t, err)
+}
+
+func TestSend_RocketChatWebhook_InvalidAttachments(t *testing.T) {
+	service := NewRocketChatService(RocketChatOptions{WebhookUrl: "http://example.invalid"})
+	err := service.Send(Notification{
+		Message:    "message",
+		RocketChat: &RocketChatNotification{Attachments: "not-json"},
+	}, Destination{Recipient: "#chan"})
+	require.ErrorContains(t, err, "failed to unmarshal attachments")
+}
+
+func TestSend_RocketChatWebhook_NonSuccessStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer ts.Close()
+
+	service := NewRocketChatService(RocketChatOptions{WebhookUrl: ts.URL})
+	err := service.Send(Notification{Message: "message"}, Destination{Recipient: "#chan"})
+	require.ErrorContains(t, err, "rocketchat webhook post error")
+}
+
+func TestSend_RocketChatWebhook_RequestCreationError(t *testing.T) {
+	service := NewRocketChatService(RocketChatOptions{WebhookUrl: "http://x\x00y"})
+	err := service.Send(Notification{Message: "message"}, Destination{Recipient: "#chan"})
+	require.ErrorContains(t, err, "failed to create request")
+}
+
+func TestSend_RocketChatWebhook_RequestError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	ts.Close()
+
+	service := NewRocketChatService(RocketChatOptions{WebhookUrl: ts.URL})
+	err := service.Send(Notification{Message: "message"}, Destination{Recipient: "#chan"})
+	require.ErrorContains(t, err, "failed to request")
+}
+
 func TestGetTemplater_RocketChat(t *testing.T) {
 	n := Notification{
 		RocketChat: &RocketChatNotification{

--- a/pkg/services/rocketchat_test.go
+++ b/pkg/services/rocketchat_test.go
@@ -1,6 +1,9 @@
 package services
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"text/template"
 
@@ -20,6 +23,42 @@ func TestValidAvatarURL(t *testing.T) {
 	assert.False(t, isValidAvatarURL("favicon.ico"))
 	assert.False(t, isValidAvatarURL("ftp://favicon.ico"))
 	assert.False(t, isValidAvatarURL("ftp://lorempixel.com/favicon.ico"))
+}
+
+func TestSend_RocketChatWebhook(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{
+			"text": "message",
+			"alias": "argocd",
+			"channel": "#my_channel",
+			"attachments": [{
+				"title": "title",
+				"collapsed": false
+			}]
+		}`, string(b))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	service := NewRocketChatService(RocketChatOptions{
+		Alias:              "argocd",
+		WebhookUrl:         ts.URL,
+		InsecureSkipVerify: true,
+	})
+	err := service.Send(Notification{
+		Message: "message",
+		RocketChat: &RocketChatNotification{
+			Attachments: `[{"title": "title"}]`,
+		},
+	}, Destination{
+		Service:   "rocketchat",
+		Recipient: "my_channel",
+	})
+	require.NoError(t, err)
 }
 
 func TestGetTemplater_RocketChat(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `webhookUrl` option to the Rocket.Chat service, using an Incoming Webhook instead of the login (email/password) flow. `webhookUrl` takes precedence when set.
- Reuses the shared `httputil` transport (`insecureSkipVerify` / transport options), so TLS to an instance behind an internal CA is supported the same way it already is for Teams and Mattermost.
- Docs updated with webhook setup steps and a callout that Rocket.Chat only honors the payload's `channel` override when the admin enables "Allow to overwrite destination channel in the body parameters" on the integration (off by default for security reasons).

## Why
Login mode requires provisioning and storing a bot user's password as a long-lived credential. A webhook token is easier to scope/rotate and avoids managing a bot account at all.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./pkg/services/... -run RocketChat -v`
- [x] `go test ./pkg/services/...` (full package, no regressions)