### PR TITLE
fix(slack): bump slack-go to v0.27.0 to support new block types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.24'
+  GOLANG_VERSION: '1.25'
 
 jobs:
   lint-go:
@@ -28,7 +28,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # renovate: datasource=go packageName=github.com/golangci/golangci-lint versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?$
-          version: v2.2.1
+          version: v2.12.2
           args: --timeout 5m --verbose
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - errorlint
     - exptostd
     - gocritic
-    - gomodguard
+    - gomodguard_v2
     - govet
     - importas
     - misspell
@@ -67,21 +67,20 @@ linters:
         - unnamedResult
         - whyNoLint
 
-    gomodguard:
+    gomodguard_v2:
       blocked:
-        modules:
-          - github.com/golang-jwt/jwt/v4:
-              recommendations:
-                - github.com/golang-jwt/jwt/v5
+        - module: github.com/golang-jwt/jwt/v4
+          recommendations:
+            - github.com/golang-jwt/jwt/v5
 
-          - github.com/imdario/mergo:
-              recommendations:
-                - dario.cat/mergo
-              reason: '`github.com/imdario/mergo` has been renamed.'
+        - module: github.com/imdario/mergo
+          recommendations:
+            - dario.cat/mergo
+          reason: '`github.com/imdario/mergo` has been renamed.'
 
-          - github.com/pkg/errors:
-              recommendations:
-                - errors
+        - module: github.com/pkg/errors
+          recommendations:
+            - errors
 
     govet:
       disable:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/notifications-engine
 
-go 1.24.0
+go 1.25
 
 require (
 	cloud.google.com/go/pubsub v1.49.0
@@ -27,7 +27,7 @@ require (
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.23
 	github.com/prometheus/client_golang v1.21.0
 	github.com/sirupsen/logrus v1.9.4
-	github.com/slack-go/slack v0.16.0
+	github.com/slack-go/slack v0.27.0
 	github.com/spf13/cast v1.7.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
-github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -158,7 +158,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
@@ -185,7 +184,6 @@ github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4 h1:4EZlYQIiyecYJlUbV
 github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4/go.mod h1:lEO7XoHJ/xNRBCxrn4h/CEB67h0kW1B0t4ooP2yrjUA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gregdel/pushover v1.3.1 h1:4bMLITOZ15+Zpi6qqoGqOPuVHCwSUvMCgVnN5Xhilfo=
@@ -306,8 +304,8 @@ github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+D
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/slack-go/slack v0.16.0 h1:khp/WCFv+Hb/B/AJaAwvcxKun0hM6grN0bUZ8xG60P8=
-github.com/slack-go/slack v0.16.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/slack-go/slack v0.27.0 h1:VWOpUzOK6UAPCCQlFxl79jhv8a/b+GOSJMnWziDJ8B8=
+github.com/slack-go/slack v0.27.0/go.mod h1:UEe+jmo9WLlwHB04qsOrTDvqM7Aa4rQL3O5wF3n0hx4=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/sony/sonyflake v1.0.0 h1:MpU6Ro7tfXwgn2l5eluf9xQvQJDROTBImNCfRXn/YeM=

--- a/pkg/services/slack.go
+++ b/pkg/services/slack.go
@@ -158,7 +158,10 @@ func buildMessageOptions(notification Notification, opts SlackOptions) (*SlackNo
 				return nil, nil, fmt.Errorf("failed to unmarshal blocks '%s' : %w", notification.Slack.Blocks, err)
 			}
 		}
-		msgOptions = append(msgOptions, slack.MsgOptionAttachments(attachments...), slack.MsgOptionBlocks(blocks.BlockSet...))
+		msgOptions = append(msgOptions, slack.MsgOptionAttachments(attachments...))
+		if notification.Slack.Blocks != "" {
+			msgOptions = append(msgOptions, slack.MsgOptionBlocks(blocks.BlockSet...))
+		}
 		slackNotification = notification.Slack
 	}
 

--- a/pkg/services/slack_test.go
+++ b/pkg/services/slack_test.go
@@ -251,9 +251,10 @@ func TestBuildMessageOptions_IconURL(t *testing.T) {
 
 		_, opts, err := buildMessageOptions(n, SlackOptions{})
 		require.NoError(t, err)
-		// Should have text + attachments + blocks (but no icon option because it's invalid)
+		// Should have text + attachments (but no icon option because it's invalid,
+		// and no blocks option since none were configured)
 		// Use GreaterOrEqual to make test less fragile to implementation changes
-		assert.GreaterOrEqual(t, len(opts), 3)
+		assert.GreaterOrEqual(t, len(opts), 2)
 	})
 }
 


### PR DESCRIPTION
Bumps `github.com/slack-go/slack` from `v0.16.0` to `v0.27.0` to support newer Block Kit blocks  (such as `table` and `markdown`).

When upgrading the library, some tests failed due to a change on how `slack-go` manages `MsgOptionBlocks` between versions:
- `v0.16.0`: calling it with zero blocks was a silent no-op.
- `v0.27.0`: calling it with zero blocks now explicitly sends `blocks=[]` (documented as intentional, to support clearing blocks on `chat.update`).

I have updated `pkg/services/slack.go` to support the same kind of behavior (no blocks when not defined, blocks when defined and empty array when `[]` is specified). This makes it work similarly to what existed previously during a `chat.update` (blocks not being stripped if they are not defined) while allowing an explicit override of existing blocks using `blocks: []`.

Also bumps `go.mod`'s `go` directive to `1.25`. This was required because `slack-go` raised its own `go` floor to `1.25` starting in the same release (`v0.18.0`) that adds `table` support. Also needed to update `golangci-lint` (used v2.12.2 to match `argo-cd` setup) and its config as it `v2.2.1` couldn't lint Go 1.25 modules.

Closes #466.
