### PR TITLE
fix: replace panic with proper error handling in fullNameByRepoURL

### DIFF
--- a/pkg/services/github.go
+++ b/pkg/services/github.go
@@ -523,18 +523,18 @@ func trunc(message string, n int) string {
 	return message
 }
 
-func fullNameByRepoURL(rawURL string) string {
+func fullNameByRepoURL(rawURL string) (string, error) {
 	parsed, err := giturls.Parse(rawURL)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to parse repository URL %q: %w", rawURL, err)
 	}
 
 	path := gitSuffix.ReplaceAllString(parsed.Path, "")
 	if pathParts := text.SplitRemoveEmpty(path, "/"); len(pathParts) >= 2 {
-		return strings.Join(pathParts[:2], "/")
+		return strings.Join(pathParts[:2], "/"), nil
 	}
 
-	return path
+	return path, nil
 }
 
 func (g gitHubService) Send(notification Notification, _ Destination) error {
@@ -542,7 +542,11 @@ func (g gitHubService) Send(notification Notification, _ Destination) error {
 		return errors.New("config is empty")
 	}
 
-	u := strings.Split(fullNameByRepoURL(notification.GitHub.repoURL), "/")
+	uParts, err := fullNameByRepoURL(notification.GitHub.repoURL)
+	if err != nil {
+		return err
+	}
+	u := strings.Split(uParts, "/")
 	if len(u) < 2 {
 		return fmt.Errorf("GitHub.repoURL (%s) does not have a `/`", notification.GitHub.repoURL)
 	}


### PR DESCRIPTION
Fixes a bug where invalid GitHub repository URLs would cause a panic instead of returning a proper error.

## Changes
- Changed `fullNameByRepoURL` to return `(string, error)` instead of panicking
- Updated the caller to handle the error gracefully
- Added descriptive error message for failed URL parsing

## Testing
- All existing tests pass
- The function now returns a clear error message for invalid URLs instead of crashing

```release-notes
[BUGFIX] Replace panic with proper error handling for invalid GitHub repository URLs
```