### PR TITLE
fix(awssqs): omit DelaySeconds for FIFO queues

### DIFF
--- a/pkg/services/awssqs.go
+++ b/pkg/services/awssqs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"strings"
 	texttemplate "text/template"
 
 	log "github.com/sirupsen/logrus"
@@ -68,9 +69,16 @@ func (s awsSqsService) Send(notif Notification, dest Destination) error {
 
 func (s awsSqsService) sendMessageInput(queueUrl *string, notif Notification) *sqs.SendMessageInput {
 	input := &sqs.SendMessageInput{
-		QueueUrl:     queueUrl,
-		MessageBody:  aws.String(notif.Message),
-		DelaySeconds: 10,
+		QueueUrl:    queueUrl,
+		MessageBody: aws.String(notif.Message),
+	}
+
+	// FIFO queues reject a per-message DelaySeconds: "When you set FifoQueue, you
+	// can't set DelaySeconds per message. You can set this parameter only on a
+	// queue level." Sending it makes every delivery to a FIFO queue fail, so only
+	// set it for standard queues. FIFO queue names always end in ".fifo".
+	if !isFifoQueue(queueUrl) {
+		input.DelaySeconds = 10
 	}
 
 	// Add MessageGroupId if available (required for FIFO queues)
@@ -79,6 +87,12 @@ func (s awsSqsService) sendMessageInput(queueUrl *string, notif Notification) *s
 	}
 
 	return input
+}
+
+// isFifoQueue reports whether the queue URL refers to a FIFO queue. Amazon SQS
+// requires the name of a FIFO queue to end in the ".fifo" suffix.
+func isFifoQueue(queueUrl *string) bool {
+	return queueUrl != nil && strings.HasSuffix(*queueUrl, ".fifo")
 }
 
 func (s awsSqsService) getQueueInput(dest Destination) *sqs.GetQueueUrlInput {

--- a/pkg/services/awssqs_test.go
+++ b/pkg/services/awssqs_test.go
@@ -251,8 +251,42 @@ func TestSendMessageInput_WithMessageGroupId_AwsSqs(t *testing.T) {
 
 	assert.Equal(t, &queueUrl, input.QueueUrl)
 	assert.Equal(t, "Hello", *input.MessageBody)
-	assert.Equal(t, int32(10), input.DelaySeconds)
+	// FIFO queues reject a per-message DelaySeconds, so it must be left unset.
+	assert.Zero(t, input.DelaySeconds)
 	assert.Equal(t, "test-group-id", *input.MessageGroupId)
+}
+
+func TestSendMessageInput_FifoQueueOmitsDelaySeconds_AwsSqs(t *testing.T) {
+	s := NewTypedAwsSqsService(AwsSqsOptions{})
+
+	for _, tc := range []struct {
+		name             string
+		queueUrl         string
+		wantDelaySeconds int32
+	}{
+		{
+			name:             "fifo queue omits DelaySeconds",
+			queueUrl:         "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue.fifo",
+			wantDelaySeconds: 0,
+		},
+		{
+			name:             "standard queue keeps DelaySeconds",
+			queueUrl:         "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+			wantDelaySeconds: 10,
+		},
+		{
+			name:             "standard queue whose name merely contains fifo",
+			queueUrl:         "https://sqs.us-east-1.amazonaws.com/123456789012/fifo-lookalike",
+			wantDelaySeconds: 10,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queueUrl := tc.queueUrl
+			input := SendMessageInput(s, &queueUrl, Notification{Message: "Hello"})
+
+			assert.Equal(t, tc.wantDelaySeconds, input.DelaySeconds)
+		})
+	}
 }
 
 func TestSendMessageInput_WithoutMessageGroupId_AwsSqs(t *testing.T) {


### PR DESCRIPTION
### What

Only set `DelaySeconds` on the `SendMessage` input for standard queues. FIFO queues never receive it.

### Why

Amazon SQS rejects a per-message `DelaySeconds` on a FIFO queue. From the [SendMessage API reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html):

> When you set `FifoQueue`, you can't set `DelaySeconds` per message. You can set this parameter only on a queue level.

`sendMessageInput` sets it unconditionally:

```go
input := &sqs.SendMessageInput{
	QueueUrl:     queueUrl,
	MessageBody:  aws.String(notif.Message),
	DelaySeconds: 10,
}
```

So every delivery to a FIFO queue fails, which makes the FIFO support added in #261 and completed in #391 unusable in practice. #391 fixed the missing `MessageGroupId`, and this is the remaining blocker on the same code path: with both in place a FIFO send finally succeeds.

Detection uses the `.fifo` suffix, which Amazon SQS [requires](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html) on FIFO queue names, so it is reliable rather than heuristic.

### Note on the existing test

`TestSendMessageInput_WithMessageGroupId_AwsSqs` uses a `.fifo` queue URL and asserted `DelaySeconds == 10`, so it encoded the broken behaviour. It now asserts the field is unset. The two standard-queue tests are unchanged and still assert `10`, so the delay behaviour for standard queues is untouched.

### Testing

Added `TestSendMessageInput_FifoQueueOmitsDelaySeconds_AwsSqs` covering a `.fifo` queue, a standard queue, and a standard queue whose name merely contains "fifo" (guards against a substring match).

```
go test ./... -count=1     # all green
gofmt -l / go vet          # clean
```
