### PR TITLE
feat(mattermost): support opt-in notification thread grouping

### DIFF
--- a/docs/services/mattermost.md
+++ b/docs/services/mattermost.md
@@ -59,11 +59,14 @@ metadata:
 You can reuse the template of slack.  
 Mattermost is compatible with attachments of Slack. See [Mattermost Integration Guide](https://docs.mattermost.com/developer/message-attachments.html).
 
+Messages can be grouped into Mattermost threads by setting `groupingKey` under the `mattermost` field. The first message for a grouping key creates a root post, and subsequent messages with the same key are sent as replies. Grouping keys are independent for each Mattermost API URL and channel. A message with an omitted or empty `groupingKey` is sent independently and does not reset an existing thread. Root post IDs are kept in memory in each notifications controller process; they are not shared between replicas, and a controller restart starts new threads.
+
 ```yaml
 template.app-deployed: |
   message: |
     Application {{.app.metadata.name}} is now running new version of deployments manifests.
   mattermost:
+    groupingKey: "{{.app.metadata.uid}}"
     attachments: |
       [{
         "title": "{{.app.metadata.name}}",

--- a/pkg/services/mattermost.go
+++ b/pkg/services/mattermost.go
@@ -3,9 +3,11 @@ package services
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	texttemplate "text/template"
 
 	httputil "github.com/argoproj/notifications-engine/pkg/util/http"
@@ -13,10 +15,15 @@ import (
 
 type MattermostNotification struct {
 	Attachments string `json:"attachments,omitempty"`
+	GroupingKey string `json:"groupingKey,omitempty"`
 }
 
 func (n *MattermostNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
 	mattermostAttachments, err := texttemplate.New(name).Funcs(f).Parse(n.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	groupingKey, err := texttemplate.New(name).Funcs(f).Parse(n.GroupingKey)
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +37,12 @@ func (n *MattermostNotification) GetTemplater(name string, f texttemplate.FuncMa
 		}
 
 		notification.Mattermost.Attachments = mattermostAttachmentsData.String()
+
+		var groupingKeyData bytes.Buffer
+		if err := groupingKey.Execute(&groupingKeyData, vars); err != nil {
+			return err
+		}
+		notification.Mattermost.GroupingKey = groupingKeyData.String()
 		return nil
 	}, nil
 }
@@ -42,14 +55,57 @@ type MattermostOptions struct {
 }
 
 type mattermostService struct {
-	opts MattermostOptions
+	opts        MattermostOptions
+	threadState *mattermostThreadState
 }
+
+var globalMattermostThreadState = newMattermostThreadState()
 
 func NewMattermostService(opts MattermostOptions) NotificationService {
-	return &mattermostService{opts: opts}
+	return newMattermostService(opts, globalMattermostThreadState)
 }
 
-func (m *mattermostService) Send(notification Notification, dest Destination) (err error) {
+func newMattermostService(opts MattermostOptions, threadState *mattermostThreadState) NotificationService {
+	return &mattermostService{opts: opts, threadState: threadState}
+}
+
+type mattermostThread struct {
+	mutex  sync.Mutex
+	rootID string
+}
+
+type mattermostThreadState struct {
+	mutex   sync.Mutex
+	threads map[string]map[string]map[string]*mattermostThread
+}
+
+func newMattermostThreadState() *mattermostThreadState {
+	return &mattermostThreadState{threads: map[string]map[string]map[string]*mattermostThread{}}
+}
+
+func (s *mattermostThreadState) get(apiURL, channelID, groupingKey string) *mattermostThread {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	channels, ok := s.threads[apiURL]
+	if !ok {
+		channels = map[string]map[string]*mattermostThread{}
+		s.threads[apiURL] = channels
+	}
+	groupingKeys, ok := channels[channelID]
+	if !ok {
+		groupingKeys = map[string]*mattermostThread{}
+		channels[channelID] = groupingKeys
+	}
+	thread, ok := groupingKeys[groupingKey]
+	if !ok {
+		thread = &mattermostThread{}
+		groupingKeys[groupingKey] = thread
+	}
+	return thread
+}
+
+func (m *mattermostService) Send(notification Notification, dest Destination) error {
 	client, err := httputil.NewServiceHTTPClient(m.opts.TransportOptions, m.opts.InsecureSkipVerify, m.opts.ApiURL, "mattermost")
 	if err != nil {
 		return err
@@ -64,36 +120,75 @@ func (m *mattermostService) Send(notification Notification, dest Destination) (e
 		}
 	}
 
+	groupingKey := ""
+	if notification.Mattermost != nil {
+		groupingKey = notification.Mattermost.GroupingKey
+	}
+	if groupingKey == "" {
+		_, err = m.post(client, notification.Message, attachments, dest.Recipient, "", false)
+		return err
+	}
+
+	thread := m.threadState.get(m.opts.ApiURL, dest.Recipient, groupingKey)
+	thread.mutex.Lock()
+	defer thread.mutex.Unlock()
+
+	rootID, err := m.post(client, notification.Message, attachments, dest.Recipient, thread.rootID, thread.rootID == "")
+	if err != nil {
+		return err
+	}
+	if thread.rootID == "" {
+		thread.rootID = rootID
+	}
+	return nil
+}
+
+func (m *mattermostService) post(client *http.Client, message string, attachments []any, channelID, rootID string, requireID bool) (string, error) {
 	body := map[string]any{
-		"channel_id": dest.Recipient,
-		"message":    notification.Message,
+		"channel_id": channelID,
+		"message":    message,
 		"props": map[string]any{
 			"attachments": attachments,
 		},
+	}
+	if rootID != "" {
+		body["root_id"] = rootID
 	}
 	b, _ := json.Marshal(body)
 
 	req, err := http.NewRequest(http.MethodPost, m.opts.ApiURL+"/api/v4/posts", bytes.NewReader(b))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+m.opts.Token)
 
 	res, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to request: %w", err)
+		return "", fmt.Errorf("failed to request: %w", err)
 	}
 	defer res.Body.Close()
 
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read body: %w", err)
+		return "", fmt.Errorf("failed to read body: %w", err)
 	}
 
 	if res.StatusCode/100 != 2 {
-		return fmt.Errorf("request to %s has failed with error code %d : %s", body, res.StatusCode, string(data))
+		return "", fmt.Errorf("request to %s has failed with error code %d : %s", body, res.StatusCode, string(data))
 	}
 
-	return nil
+	if !requireID {
+		return "", nil
+	}
+	var post struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &post); err != nil {
+		return "", fmt.Errorf("failed to unmarshal Mattermost post response: %w", err)
+	}
+	if post.ID == "" {
+		return "", errors.New("mattermost post response does not contain an id")
+	}
+	return post.ID, nil
 }

--- a/pkg/services/mattermost_test.go
+++ b/pkg/services/mattermost_test.go
@@ -1,15 +1,25 @@
 package services
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type mattermostTestPost struct {
+	ChannelID string `json:"channel_id"`
+	Message   string `json:"message"`
+	RootID    string `json:"root_id"`
+}
 
 func TestSend_Mattermost(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -73,6 +83,7 @@ func TestGetTemplater_Mattermost(t *testing.T) {
 	n := Notification{
 		Mattermost: &MattermostNotification{
 			Attachments: "{{.foo}}",
+			GroupingKey: "{{.app}}",
 		},
 	}
 	templater, err := n.GetTemplater("", template.FuncMap{})
@@ -82,9 +93,361 @@ func TestGetTemplater_Mattermost(t *testing.T) {
 	var notification Notification
 	err = templater(&notification, map[string]any{
 		"foo": "hello",
+		"app": "my-app",
 	})
 
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello", notification.Mattermost.Attachments)
+	assert.Equal(t, "my-app", notification.Mattermost.GroupingKey)
+}
+
+func TestSend_MattermostThreading(t *testing.T) {
+	var mutex sync.Mutex
+	posts := make([]mattermostTestPost, 0)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		posts = append(posts, post)
+		postNumber := len(posts)
+		mutex.Unlock()
+		_, _ = fmt.Fprintf(w, `{"id":"post-%d"}`, postNumber)
+	}))
+	defer ts.Close()
+
+	state := newMattermostThreadState()
+	newService := func() NotificationService {
+		return newMattermostService(MattermostOptions{ApiURL: ts.URL, Token: "token"}, state)
+	}
+	destination := Destination{Service: "mattermost", Recipient: "channel"}
+	grouped := func(message string) Notification {
+		return Notification{Message: message, Mattermost: &MattermostNotification{GroupingKey: "app-uid"}}
+	}
+
+	require.NoError(t, newService().Send(grouped("first error"), destination))
+	// Recreating a service in the same process must preserve the root post.
+	require.NoError(t, newService().Send(grouped("second error"), destination))
+	// Notifications without groupingKey remain independent posts.
+	require.NoError(t, newService().Send(Notification{Message: "success"}, destination))
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.Len(t, posts, 3)
+	assert.Empty(t, posts[0].RootID)
+	assert.Equal(t, "post-1", posts[1].RootID)
+	assert.Empty(t, posts[2].RootID)
+}
+
+func TestSend_MattermostThreadStateRestart(t *testing.T) {
+	var mutex sync.Mutex
+	posts := make([]mattermostTestPost, 0)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		posts = append(posts, post)
+		postNumber := len(posts)
+		mutex.Unlock()
+		_, _ = fmt.Fprintf(w, `{"id":"post-%d"}`, postNumber)
+	}))
+	defer ts.Close()
+
+	opts := MattermostOptions{ApiURL: ts.URL, Token: "token"}
+	destination := Destination{Service: "mattermost", Recipient: "channel"}
+	notification := Notification{Mattermost: &MattermostNotification{GroupingKey: "app-uid"}}
+	require.NoError(t, newMattermostService(opts, newMattermostThreadState()).Send(notification, destination))
+	require.NoError(t, newMattermostService(opts, newMattermostThreadState()).Send(notification, destination))
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.Len(t, posts, 2)
+	assert.Empty(t, posts[0].RootID)
+	assert.Empty(t, posts[1].RootID)
+}
+
+func TestSend_MattermostConcurrentThreadCreation(t *testing.T) {
+	const sends = 32
+	var mutex sync.Mutex
+	posts := make([]mattermostTestPost, 0, sends)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		posts = append(posts, post)
+		postNumber := len(posts)
+		mutex.Unlock()
+		_, _ = fmt.Fprintf(w, `{"id":"post-%d"}`, postNumber)
+	}))
+	defer ts.Close()
+
+	service := newMattermostService(MattermostOptions{ApiURL: ts.URL, Token: "token"}, newMattermostThreadState())
+	destination := Destination{Service: "mattermost", Recipient: "channel"}
+	start := make(chan struct{})
+	errs := make(chan error, sends)
+	var wg sync.WaitGroup
+	for i := 0; i < sends; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs <- service.Send(Notification{
+				Message:    fmt.Sprintf("error-%d", i),
+				Mattermost: &MattermostNotification{GroupingKey: "app-uid"},
+			}, destination)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.Len(t, posts, sends)
+	rootPosts := 0
+	for _, post := range posts {
+		if post.RootID == "" {
+			rootPosts++
+		} else {
+			assert.Equal(t, "post-1", post.RootID)
+		}
+	}
+	assert.Equal(t, 1, rootPosts)
+}
+
+func TestSend_MattermostDoesNotSerializeUnrelatedThreads(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if post.Message == "first" {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		_, _ = io.WriteString(w, `{"id":"root"}`)
+	}))
+	defer ts.Close()
+	defer release()
+
+	service := newMattermostService(MattermostOptions{ApiURL: ts.URL}, newMattermostThreadState())
+	destination := Destination{Recipient: "channel"}
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- service.Send(Notification{
+			Message:    "first",
+			Mattermost: &MattermostNotification{GroupingKey: "app-1"},
+		}, destination)
+	}()
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first grouped send did not reach the server")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- service.Send(Notification{
+			Message:    "second",
+			Mattermost: &MattermostNotification{GroupingKey: "app-2"},
+		}, destination)
+	}()
+	select {
+	case err := <-secondDone:
+		release()
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		release()
+		t.Fatal("send for an unrelated grouping key was blocked")
+	}
+	require.NoError(t, <-firstDone)
+}
+
+func TestSend_MattermostThreadIsolation(t *testing.T) {
+	type recorder struct {
+		mutex sync.Mutex
+		posts []mattermostTestPost
+	}
+	newServer := func(recorder *recorder) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var post mattermostTestPost
+			if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			recorder.mutex.Lock()
+			recorder.posts = append(recorder.posts, post)
+			postNumber := len(recorder.posts)
+			recorder.mutex.Unlock()
+			_, _ = fmt.Fprintf(w, `{"id":"post-%d"}`, postNumber)
+		}))
+	}
+
+	firstRecorder := &recorder{}
+	firstServer := newServer(firstRecorder)
+	defer firstServer.Close()
+	secondRecorder := &recorder{}
+	secondServer := newServer(secondRecorder)
+	defer secondServer.Close()
+	state := newMattermostThreadState()
+	firstService := newMattermostService(MattermostOptions{ApiURL: firstServer.URL}, state)
+	secondService := newMattermostService(MattermostOptions{ApiURL: secondServer.URL}, state)
+	notify := func(service NotificationService, channel, key string) {
+		require.NoError(t, service.Send(
+			Notification{Mattermost: &MattermostNotification{GroupingKey: key}},
+			Destination{Service: "mattermost", Recipient: channel},
+		))
+	}
+
+	notify(firstService, "channel-1", "app-1")
+	notify(firstService, "channel-1", "app-1")
+	notify(firstService, "channel-1", "app-2")
+	notify(firstService, "channel-2", "app-1")
+	notify(secondService, "channel-1", "app-1")
+
+	firstRecorder.mutex.Lock()
+	defer firstRecorder.mutex.Unlock()
+	require.Len(t, firstRecorder.posts, 4)
+	assert.Empty(t, firstRecorder.posts[0].RootID)
+	assert.Equal(t, "post-1", firstRecorder.posts[1].RootID)
+	assert.Empty(t, firstRecorder.posts[2].RootID)
+	assert.Empty(t, firstRecorder.posts[3].RootID)
+	secondRecorder.mutex.Lock()
+	defer secondRecorder.mutex.Unlock()
+	require.Len(t, secondRecorder.posts, 1)
+	assert.Empty(t, secondRecorder.posts[0].RootID)
+}
+
+func TestSend_MattermostRootFailuresAreNotCached(t *testing.T) {
+	var mutex sync.Mutex
+	posts := make([]mattermostTestPost, 0, 3)
+	requestNumber := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		posts = append(posts, post)
+		requestNumber++
+		currentRequest := requestNumber
+		mutex.Unlock()
+		if currentRequest == 1 {
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"id":"post-%d"}`, currentRequest)
+	}))
+	defer ts.Close()
+
+	service := newMattermostService(MattermostOptions{ApiURL: ts.URL}, newMattermostThreadState())
+	destination := Destination{Recipient: "channel"}
+	notification := Notification{Mattermost: &MattermostNotification{GroupingKey: "app-uid"}}
+	require.Error(t, service.Send(notification, destination))
+	require.NoError(t, service.Send(notification, destination))
+	require.NoError(t, service.Send(notification, destination))
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.Len(t, posts, 3)
+	assert.Empty(t, posts[0].RootID)
+	assert.Empty(t, posts[1].RootID)
+	assert.Equal(t, "post-2", posts[2].RootID)
+}
+
+func TestSend_MattermostInvalidRootResponsesAreNotCached(t *testing.T) {
+	var mutex sync.Mutex
+	posts := make([]mattermostTestPost, 0, 3)
+	requestNumber := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		posts = append(posts, post)
+		requestNumber++
+		currentRequest := requestNumber
+		mutex.Unlock()
+		switch currentRequest {
+		case 1:
+			_, _ = io.WriteString(w, `{}`)
+		case 2:
+			_, _ = io.WriteString(w, `not-json`)
+		default:
+			_, _ = io.WriteString(w, `{"id":"post-3"}`)
+		}
+	}))
+	defer ts.Close()
+
+	service := newMattermostService(MattermostOptions{ApiURL: ts.URL}, newMattermostThreadState())
+	destination := Destination{Recipient: "channel"}
+	notification := Notification{Mattermost: &MattermostNotification{GroupingKey: "app-uid"}}
+	require.EqualError(t, service.Send(notification, destination), "mattermost post response does not contain an id")
+	require.ErrorContains(t, service.Send(notification, destination), "failed to unmarshal Mattermost post response")
+	require.NoError(t, service.Send(notification, destination))
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.Len(t, posts, 3)
+	for _, post := range posts {
+		assert.Empty(t, post.RootID)
+	}
+}
+
+func TestSend_MattermostReplyFailurePreservesRoot(t *testing.T) {
+	var mutex sync.Mutex
+	posts := make([]mattermostTestPost, 0, 3)
+	requestNumber := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var post mattermostTestPost
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		posts = append(posts, post)
+		requestNumber++
+		currentRequest := requestNumber
+		mutex.Unlock()
+		if currentRequest == 2 {
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"id":"post-%d"}`, currentRequest)
+	}))
+	defer ts.Close()
+
+	service := newMattermostService(MattermostOptions{ApiURL: ts.URL}, newMattermostThreadState())
+	destination := Destination{Recipient: "channel"}
+	notification := Notification{Mattermost: &MattermostNotification{GroupingKey: "app-uid"}}
+	require.NoError(t, service.Send(notification, destination))
+	require.Error(t, service.Send(notification, destination))
+	require.NoError(t, service.Send(notification, destination))
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.Len(t, posts, 3)
+	assert.Empty(t, posts[0].RootID)
+	assert.Equal(t, "post-1", posts[1].RootID)
+	assert.Equal(t, "post-1", posts[2].RootID)
 }


### PR DESCRIPTION
## Problem and behavior

Repeated Mattermost notifications always create top-level posts. Add optional templated `mattermost.groupingKey`: the first delivery creates a root post and later deliveries with the same API URL, channel and key become replies. Omitting the key preserves existing behavior, allowing success notifications to stay separate.

Root IDs are held in process memory and survive service reconstruction, but not process restart. Sends are serialized per group; unrelated groups remain independent. Failed root requests do not populate the state, and failed replies retain the existing root without falling back to another top-level post.

## Validation

- `make test`: full repository tests with race detector and coverage passed.
- `go test -race ./pkg/services`: passed.
- `golangci-lint v2.2.1 run --timeout 5m` for the full repository: passed.
- `go mod download && go mod tidy && make generate`: no module or generated-code changes.
- Independent review completed without blocking findings.

Unit tests use a mock HTTP server. A separate integration check also passed against an isolated Mattermost Team Edition 10.11.0 container and PostgreSQL 16. The harness sent messages through the notifications-engine service API and read actual persisted posts back from Mattermost:

- Repeated failures and service recreation reused the first post as `root_id`.
- Two success notifications created distinct top-level posts.
- A different application created an independent thread.
- Twelve concurrent initial sends created exactly one root and eleven replies.
- A new sender process created a fresh root.

The fixture used local test credentials and was removed after verification. This checks compatibility with Mattermost 10.11.0; it does not claim coverage of all server versions. Mattermost image digest: `sha256:68f9788a401c0e44caa2b9de413aa2da75da59d75725237a8098820721da0a13`.

Tested implementation commit: `e32498c81e255341c7bb987c7e2eb85c4c5c1b9c`.

## Limitations

No persistence across controller restarts, deleted-root recovery or exactly-once guarantee across ambiguous HTTP failures. Group keys should have bounded cardinality, such as application UID. Trigger deduplication is unchanged.

## Contribution

This change was prepared with AI assistance and reviewed before submission. Link the related issue before opening the upstream PR.

Related issue: https://github.com/argoproj/notifications-engine/issues/471
